### PR TITLE
[UXIT-3434] ButtonBase and ButtonLink components

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,9 @@
   --color-brand-50: #10B4FF;
   --color-brand-100: #003669;
   --color-brand-200: #001D3B;
+  
+  --color-button-brand: #086dc5;
+  --color-button-brand-disabled: #005280;
 
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/components/ui/button/button-base.tsx
+++ b/src/components/ui/button/button-base.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center font-medium px-5 py-3  rounded-sm transition-colors w-full disabled:pointer-events-none disabled:cursor-not-allowed',
+  {
+    variants: {
+      variant: {
+        primary: [
+          'bg-button-brand text-zinc-100 border border-transparent disabled:bg-button-brand-disabled',
+        ],
+        secondary: ['bg-transparent text-zinc-100 border border-zinc-800'],
+      },
+      loading: {
+        true: 'cursor-wait',
+        false: 'cursor-pointer',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      loading: false,
+    },
+  },
+)
+
+type ButtonBaseProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants> & {
+    loading?: boolean
+  }
+
+function ButtonBase({
+  className,
+  variant,
+  loading,
+  children,
+  disabled,
+  ...props
+}: ButtonBaseProps) {
+  return (
+    <button
+      className={cn(buttonVariants({ variant, loading, className }))}
+      disabled={disabled || loading}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}
+
+export { ButtonBase, type ButtonBaseProps }

--- a/src/components/ui/button/button-link.tsx
+++ b/src/components/ui/button/button-link.tsx
@@ -1,0 +1,23 @@
+import { ButtonBase, type ButtonBaseProps } from './button-base'
+
+type ButtonLinkProps = Omit<ButtonBaseProps, 'onClick'> & {
+  href: string
+}
+
+function ButtonLink({
+  href,
+  children,
+  disabled,
+  variant = 'secondary',
+  ...props
+}: ButtonLinkProps) {
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      <ButtonBase disabled={disabled} variant={variant} {...props}>
+        {children}
+      </ButtonBase>
+    </a>
+  )
+}
+
+export { ButtonLink }


### PR DESCRIPTION
## Description

This PR:

- Introduces `ButtonBase` and `ButtonLink` components for reusable button functionality
- Updates global CSS to include new button color variables

NOTE: we're missing focus/hover styles, I created a ticket for that, [see here](https://www.notion.so/filecoin/Filecoin-Pin-Add-focus-hover-states-2867631f282580e69f09da6e95582574?v=2857631f2825803a90be000ca2ce4126&source=copy_link).