### PR TITLE
[UXIT-3456] Update import paths and adjust linting rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -75,12 +75,7 @@
       "correctness": {
         "noUnusedVariables": "warn",
         "noInvalidBuiltinInstantiation": "error",
-        "useImportExtensions": {
-          "level": "error",
-          "options": {
-            "forceJsExtensions": false
-          }
-        }
+        "useImportExtensions": "off"
       },
       "style": {
         "noNamespace": "error",

--- a/src/components/layout/sidebar-links.tsx
+++ b/src/components/layout/sidebar-links.tsx
@@ -1,6 +1,6 @@
 import { GitBranchIcon, Github, Terminal } from 'lucide-react'
-import { LinkIcon } from '../ui/link-icon.tsx'
-import { LinkIconContainer } from '../ui/link-icon-container.tsx'
+import { LinkIcon } from '@/components/ui/link-icon'
+import { LinkIconContainer } from '@/components/ui/link-icon-container'
 
 export default function SidebarLinks() {
   return (

--- a/src/components/layout/sidebar-steps.tsx
+++ b/src/components/layout/sidebar-steps.tsx
@@ -1,6 +1,6 @@
-import { ButtonLink } from '../ui/button/button-link.tsx'
-import { StepItem } from '../ui/step-item.tsx'
-import { StepItemContainer } from '../ui/step-item-container.tsx'
+import { ButtonLink } from '@/components/ui/button/button-link'
+import { StepItem } from '@/components/ui/step-item'
+import { StepItemContainer } from '@/components/ui/step-item-container'
 
 export default function SidebarSteps() {
   return (

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,5 +1,5 @@
-import SidebarLinks from './sidebar-links.tsx'
-import SidebarSteps from './sidebar-steps.tsx'
+import SidebarLinks from './sidebar-links'
+import SidebarSteps from './sidebar-steps'
 
 export default function Sidebar() {
   return (

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,7 +1,7 @@
 import * as AccordionPrimitive from '@radix-ui/react-accordion'
 import { ChevronDownIcon } from 'lucide-react'
 
-import { cn } from '../../utils/cn.ts'
+import { cn } from '@/utils/cn'
 
 function Accordion({ ...props }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
   return <AccordionPrimitive.Root data-slot="accordion" {...props} />

--- a/src/components/ui/badge-status.tsx
+++ b/src/components/ui/badge-status.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from 'class-variance-authority'
 import { CircleCheck, LoaderCircle } from 'lucide-react'
-import { cn } from '../../utils/cn.ts'
-import type { UploadProgress } from '../upload/upload-progress.tsx'
+import type { UploadProgress } from '@/components/upload/upload-progress'
+import { cn } from '@/utils/cn'
 
 export type Status = UploadProgress['status'] | 'pinned'
 

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,7 +1,7 @@
-import type { UploadProgress } from '../upload/upload-progress.tsx'
-import { BadgeStatus } from './badge-status.tsx'
-import { Heading } from './heading.tsx'
-import { Spinner } from './spinner.tsx'
+import { BadgeStatus } from '@/components/ui/badge-status'
+import { Heading } from '@/components/ui/heading'
+import { Spinner } from '@/components/ui/spinner'
+import type { UploadProgress } from '@/components/upload/upload-progress'
 
 type CardWrapperProps = {
   children: React.ReactNode

--- a/src/components/ui/file-info.tsx
+++ b/src/components/ui/file-info.tsx
@@ -1,5 +1,5 @@
-import { BadgeStatus, type Status } from './badge-status.tsx'
-import { Heading } from './heading.tsx'
+import { BadgeStatus, type Status } from '@/components/ui/badge-status'
+import { Heading } from '@/components/ui/heading'
 
 type FileInfoProps = {
   fileName: string

--- a/src/components/ui/heading.tsx
+++ b/src/components/ui/heading.tsx
@@ -1,5 +1,5 @@
 import { cva, type VariantProps } from 'class-variance-authority'
-import { cn } from '../../utils/cn.ts'
+import { cn } from '@/utils/cn'
 
 export type HeadingProps = VariantProps<typeof headingVariants> & {
   tag: 'h1' | 'h2' | 'h3' | 'h4'

--- a/src/components/ui/loading-state.tsx
+++ b/src/components/ui/loading-state.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from './spinner.tsx'
+import { Spinner } from '@/components/ui/spinner'
 
 interface LoadingStateProps {
   message: string

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,6 +1,6 @@
 import { Loader2Icon, type LucideProps } from 'lucide-react'
 
-import { cn } from '../../utils/cn.ts'
+import { cn } from '@/utils/cn'
 
 const sizes = {
   xs: 16,

--- a/src/components/ui/step-item.tsx
+++ b/src/components/ui/step-item.tsx
@@ -1,4 +1,4 @@
-import { BadgeNumber } from './badge-number.tsx'
+import { BadgeNumber } from '@/components/ui/badge-number'
 
 type StepItemProps = {
   step: number

--- a/src/components/upload/upload-progress.tsx
+++ b/src/components/upload/upload-progress.tsx
@@ -1,11 +1,11 @@
 import { useCallback } from 'react'
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '../ui/accordion.tsx'
-import { ButtonLink } from '../ui/button/button-link.tsx'
-import { Card } from '../ui/card.tsx'
-import { DownloadButton } from '../ui/download-button.tsx'
-import { FileInfo } from '../ui/file-info.tsx'
-import { ProgressBar } from '../ui/progress-bar.tsx'
-import { TextWithCopyToClipboard } from '../ui/text-with-copy-to-clipboard.tsx'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
+import { ButtonLink } from '@/components/ui/button/button-link'
+import { Card } from '@/components/ui/card'
+import { DownloadButton } from '@/components/ui/download-button'
+import { FileInfo } from '@/components/ui/file-info'
+import { ProgressBar } from '@/components/ui/progress-bar'
+import { TextWithCopyToClipboard } from '@/components/ui/text-with-copy-to-clipboard'
 
 export interface UploadProgress {
   step: 'creating-car' | 'uploading-car' | 'checking-readiness' | 'announcing-cids' | 'finalizing-transaction'


### PR DESCRIPTION
## Description

This PR:

- Changed import paths to use absolute imports for better clarity and consistency across components.
- Updated the `useImportExtensions` rule in `biome.json` to be turned off, simplifying the linting configuration
- I've only done this for the `components` folder and the `upload-progress'  – for the rest we can fix as we go along? What do you think?