### PR TITLE
Mark files as pinned regardless of "CID not yet indexed by IPNI" errors

### DIFF
--- a/src/components/layout/content.tsx
+++ b/src/components/layout/content.tsx
@@ -135,7 +135,7 @@ export default function Content() {
             network={wallet.status === 'ready' ? wallet.data.network : undefined}
             onToggleExpanded={() => setIsExpanded(!isExpanded)}
             pieceCid={uploadState.pieceCid}
-            progress={uploadState.progress}
+            progresses={uploadState.progress}
             providerName={providerInfo?.name || (providerInfo?.id ? String(providerInfo.id) : undefined)}
             transactionHash={uploadState.transactionHash}
           />
@@ -169,7 +169,7 @@ export default function Content() {
                 })
               }}
               pieceCid={upload.pieceCid}
-              progress={COMPLETED_PROGRESS}
+              progresses={COMPLETED_PROGRESS}
               providerName={upload.providerName}
               transactionHash={upload.transactionHash}
             />

--- a/src/components/upload/progress-card-combined.tsx
+++ b/src/components/upload/progress-card-combined.tsx
@@ -4,17 +4,17 @@ import { Card } from '../ui/card.tsx'
 import { ProgressBar } from '../ui/progress-bar.tsx'
 
 interface ProgressCardCombinedProps {
-  progress: Progress[]
+  progresses: Array<Progress>
   getCombinedFirstStageStatus: () => Progress['status']
   getCombinedFirstStageProgress: () => number
 }
 
 function ProgressCardCombined({
-  progress,
+  progresses,
   getCombinedFirstStageStatus,
   getCombinedFirstStageProgress,
 }: ProgressCardCombinedProps) {
-  const hasCreatingCarStep = progress.find((p) => p.step === 'creating-car')
+  const hasCreatingCarStep = progresses.find((progress) => progress.step === 'creating-car')
 
   const firstStagestatus = getCombinedFirstStageStatus()
   const firstStageProgress = getCombinedFirstStageProgress()

--- a/src/components/upload/progress-card.tsx
+++ b/src/components/upload/progress-card.tsx
@@ -5,23 +5,25 @@ import { Card } from '../ui/card.tsx'
 import { TextWithCopyToClipboard } from '../ui/text-with-copy-to-clipboard.tsx'
 
 interface ProgressCardProps {
-  step: Progress
+  progress: Progress
   transactionHash?: string
 }
 
-function ProgressCard({ step, transactionHash }: ProgressCardProps) {
+function ProgressCard({ progress, transactionHash }: ProgressCardProps) {
   return (
     <Card.Wrapper>
       <Card.Header
-        estimatedTime={getEstimatedTime(step.step)}
-        status={step.status}
-        title={getStepLabel(step.step)}
+        estimatedTime={getEstimatedTime(progress.step)}
+        status={progress.status}
+        title={getStepLabel(progress.step)}
         withSpinner
       />
 
-      {step.error && <Alert message={step.error} variant="error" />}
+      {progress.error && (
+        <Alert message={progress.error} variant={progress.step === 'announcing-cids' ? 'warning' : 'error'} />
+      )}
 
-      {step.step === 'finalizing-transaction' && transactionHash && (
+      {progress.step === 'finalizing-transaction' && transactionHash && (
         <Card.Content>
           <TextWithCopyToClipboard
             href={`https://filecoin-testnet.blockscout.com/tx/${transactionHash}`}

--- a/src/components/upload/upload-completed.tsx
+++ b/src/components/upload/upload-completed.tsx
@@ -1,3 +1,5 @@
+import { INPI_ERROR_MESSAGE } from '@/hooks/use-filecoin-upload.ts'
+import { Alert } from '../ui/alert.tsx'
 import { ButtonLink } from '../ui/button/button-link.tsx'
 import { Card } from '../ui/card.tsx'
 import { DownloadButton } from '../ui/download-button.tsx'
@@ -9,17 +11,25 @@ interface UploadCompletedProps {
   pieceCid?: string
   providerName?: string
   network?: string
+  hasIpniFailure?: boolean // New prop
 }
 
-function UploadCompleted({ cid, pieceCid, providerName, network }: UploadCompletedProps) {
+function UploadCompleted({ cid, pieceCid, providerName, network, hasIpniFailure }: UploadCompletedProps) {
   return (
     <>
       <Card.Wrapper>
+        {hasIpniFailure && <Alert message={INPI_ERROR_MESSAGE} variant="warning" />}
         <Card.InfoRow
-          subtitle={<TextWithCopyToClipboard href={`https://dweb.link/ipfs/${cid}`} text={cid} />}
+          subtitle={
+            hasIpniFailure ? (
+              <TextWithCopyToClipboard text={cid} />
+            ) : (
+              <TextWithCopyToClipboard href={`https://dweb.link/ipfs/${cid}`} text={cid} />
+            )
+          }
           title="IPFS Root CID"
         >
-          <DownloadButton href={`https://dweb.link/ipfs/${cid}`} />
+          {!hasIpniFailure && <DownloadButton href={`https://dweb.link/ipfs/${cid}`} />}
         </Card.InfoRow>
       </Card.Wrapper>
 

--- a/src/components/upload/upload-progress.tsx
+++ b/src/components/upload/upload-progress.tsx
@@ -4,13 +4,13 @@ import { ProgressCard } from './progress-card.tsx'
 import { ProgressCardCombined } from './progress-card-combined.tsx'
 
 interface UploadProgressProps {
-  progress: Progress[]
+  progresses: Array<Progress>
   transactionHash?: string
   getCombinedFirstStageStatus: () => Progress['status']
   getCombinedFirstStageProgress: () => number
 }
 function UploadProgress({
-  progress,
+  progresses,
   transactionHash,
   getCombinedFirstStageStatus,
   getCombinedFirstStageProgress,
@@ -20,13 +20,13 @@ function UploadProgress({
       <ProgressCardCombined
         getCombinedFirstStageProgress={getCombinedFirstStageProgress}
         getCombinedFirstStageStatus={getCombinedFirstStageStatus}
-        progress={progress}
+        progresses={progresses}
       />
 
-      {progress
-        .filter((step) => !COMBINED_STEPS.includes(step.step))
-        .map((step) => (
-          <ProgressCard key={step.step} step={step} transactionHash={transactionHash} />
+      {progresses
+        .filter((progress) => !COMBINED_STEPS.includes(progress.step))
+        .map((progress) => (
+          <ProgressCard key={progress.step} progress={progress} transactionHash={transactionHash} />
         ))}
     </>
   )

--- a/src/hooks/use-filecoin-upload.ts
+++ b/src/hooks/use-filecoin-upload.ts
@@ -37,6 +37,9 @@ const initialProgress: Progress[] = [
   { step: 'finalizing-transaction', progress: 0, status: 'pending' },
 ]
 
+export const INPI_ERROR_MESSAGE =
+  "CID not yet indexed by IPNI. It's stored on Filecoin and fetchable now, but may take time to appear on IPFS."
+
 export const useFilecoinUpload = () => {
   const context = useContext(FilecoinPinContext)
   if (!context) {
@@ -77,7 +80,7 @@ export const useFilecoinUpload = () => {
       updateProgress('announcing-cids', {
         status: 'error',
         progress: 0,
-        error: 'CID not yet indexed by IPNI. The file is stored but may take time to be discoverable on the network.',
+        error: INPI_ERROR_MESSAGE,
       })
     },
   })


### PR DESCRIPTION
This PR implements this piece of feedback from @jennijuju:

> CID not yet indexed by IPNI." error happens, the file should still be marked as pinned when the third step is completed, because it will be already pinned on Filecoin. In that case, the IPFS CID shouldn't be a link and the warning message would show up within the IPFS card, but people would still be able to see the Filecoin CID, the provider details, the download on Filecoin button and the view proofs button.

Its ignores `announcing-cids` errors from the `isCompleted` computation and adds an `hasIpniFailure` prop in `upload-completed.tsx` to display IPNI errors as warnings.

https://filecoinproject.slack.com/docs/TEHTVS1L6/F09M3MN6508