### PR TITLE
fix: use reliable provider id for now

### DIFF
--- a/.github/workflows/filecoin-pin-upload-action.yml
+++ b/.github/workflows/filecoin-pin-upload-action.yml
@@ -36,6 +36,8 @@ jobs:
       # The action will create a CAR file from the downloaded artifacts and upload to Filecoin
       - name: Upload to Filecoin
         uses: filecoin-project/filecoin-pin/upload-action@master
+        env:
+          PROVIDER_ID: 2
         with:
           path: dist  # Path to the downloaded build artifacts
           walletPrivateKey: ${{ secrets.WALLET_PRIVATE_KEY }}


### PR DESCRIPTION
Implement hardcoded provider id for now. see https://github.com/filecoin-project/filecoin-pin/pull/116
