### PR TITLE
fix: don't show cid link if ipni check fails

### DIFF
--- a/src/components/upload/upload-completed.tsx
+++ b/src/components/upload/upload-completed.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react'
 import { INPI_ERROR_MESSAGE } from '@/hooks/use-filecoin-upload.ts'
+import { useIpniCheck } from '../../hooks/use-ipni-check.ts'
 import { Alert } from '../ui/alert.tsx'
 import { ButtonLink } from '../ui/button/button-link.tsx'
 import { Card } from '../ui/card.tsx'
@@ -11,10 +13,25 @@ interface UploadCompletedProps {
   pieceCid?: string
   providerName?: string
   network?: string
-  hasIpniFailure?: boolean // New prop
 }
 
-function UploadCompleted({ cid, pieceCid, providerName, network, hasIpniFailure }: UploadCompletedProps) {
+function UploadCompleted({ cid, pieceCid, providerName, network }: UploadCompletedProps) {
+  const [hasIpniFailure, setHasIpniFailure] = useState(false)
+
+  /**
+   * Get the status of the IPNI check to change how we render the completed state.
+   */
+  useIpniCheck({
+    cid,
+    isActive: true,
+    onSuccess: () => setHasIpniFailure(false),
+    maxAttempts: 1,
+    onError: (error) => {
+      console.error('[UploadCompleted] IPNI check failed:', error)
+      setHasIpniFailure(true)
+    },
+  })
+
   return (
     <>
       <Card.Wrapper>

--- a/src/components/upload/upload-status.tsx
+++ b/src/components/upload/upload-status.tsx
@@ -77,8 +77,6 @@ function UploadStatus({
   // Check if any step is in error (excluding IPNI failures)
   const hasError = progresses.some((p) => p.status === 'error' && p.step !== 'announcing-cids')
 
-  const hasIpniFailure = progresses.some((p) => p.step === 'announcing-cids' && p.status === 'error')
-
   // Determine the badge status for the file card header
   function getBadgeStatus() {
     if (isCompleted) return 'pinned'
@@ -104,13 +102,7 @@ function UploadStatus({
 
         <AccordionContent className="space-y-6 mt-6">
           {isCompleted && cid ? (
-            <UploadCompleted
-              cid={cid}
-              hasIpniFailure={hasIpniFailure}
-              network={network}
-              pieceCid={pieceCid}
-              providerName={providerName}
-            />
+            <UploadCompleted cid={cid} network={network} pieceCid={pieceCid} providerName={providerName} />
           ) : (
             <UploadProgress
               getCombinedFirstStageProgress={getCombinedFirstStageProgress}


### PR DESCRIPTION
Success:

<img width="739" height="566" alt="image" src="https://github.com/user-attachments/assets/75627ce1-d472-4f89-89f4-52e53df19ba1" />


Failure:

<img width="705" height="546" alt="image" src="https://github.com/user-attachments/assets/d9ddd138-ddd8-4c28-8038-7504d3036fd5" />
