### PR TITLE
Enable "Upload" button as soon as a user has selected a file

### DIFF
--- a/src/components/upload/drag-n-drop.tsx
+++ b/src/components/upload/drag-n-drop.tsx
@@ -19,15 +19,14 @@ export default function DragNDrop({ onFileSelected, onUpload, isUploading }: Dra
     throw new Error('DragNDrop must be used within FilecoinPinProvider')
   }
 
-  const { dataSet, storageContext } = context
 
   const fileIsSelected = Boolean(file)
-  const buttonIsDisabled = !fileIsSelected || isUploading || !storageContext
-  const isLoading = dataSet.status === 'initializing' || isUploading
+  const buttonIsDisabled = !fileIsSelected || isUploading
 
   function uploadFile() {
     if (file) {
       onUpload(file)
+      setFile(null)
     }
   }
 
@@ -53,7 +52,7 @@ export default function DragNDrop({ onFileSelected, onUpload, isUploading }: Dra
           <Button disabled={buttonIsDisabled} onClick={clearFile} variant="secondary">
             Cancel
           </Button>
-          <Button disabled={buttonIsDisabled} loading={isLoading} onClick={uploadFile} variant="primary">
+          <Button disabled={buttonIsDisabled} loading={isUploading} onClick={uploadFile} variant="primary">
             Upload
           </Button>
         </div>


### PR DESCRIPTION
- Removed unused `storageContext` check for button disabled state.
- Updated button loading state to directly reflect `isUploading` instead of using a derived `isLoading` state.