### PR TITLE
fix: retry on CreateDataSet nonce collision

### DIFF
--- a/src/hooks/use-data-set-manager.ts
+++ b/src/hooks/use-data-set-manager.ts
@@ -267,6 +267,7 @@ export function useDataSetManager({
 
           // Release the guard before retrying
           isEnsuringDataSetRef.current = false
+          setDataSet((prev) => ({ ...prev, status: 'idle' }))
 
           return ensureDataSet() // Recursive retry
         }


### PR DESCRIPTION
Ref: https://filecoinproject.slack.com/archives/C095WFA0QK1/p1760475750636059

There are two variations of the errors that we can expect to receive from the server, for [reasons](https://github.com/filecoin-project/lotus/pull/13389):

```
failed to estimate gas: failed to estimate gas: message execution failed: exit 33, reason: message failed with backtrace:
00: f0169791 (method 3844450837) -- contract reverted at 75 (33)
01: f0169791 (method 6) -- contract reverted at 4535 (33)
02: f0169800 (method 3844450837) -- contract reverted at 75 (33)
03: f0169800 (method 6) -- contract reverted at 18957 (33)
 (RetCode=33)
```

```
failed to estimate gas: message execution failed (exit=[33], revert reason=[message failed with backtrace:
00: f0169791 (method 3844450837) -- contract reverted at 75 (33)
01: f0169791 (method 6) -- contract reverted at 4535 (33)
02: f0169800 (method 3844450837) -- contract reverted at 75 (33)
03: f0169800 (method 6) -- contract reverted at 18957 (33)
 (RetCode=33)], vm error=[0x42d750dc0000000000000000000000000542c82a785fab8b53c7c59aaad7093d87265f3a0000000000000000000000009050bdd028ba54a01777cd8c6d0a59d5bc52fdbf])
```