### PR TITLE
ci: Implement random provider selection for uploads

### DIFF
--- a/.github/workflows/filecoin-pin-upload.yml
+++ b/.github/workflows/filecoin-pin-upload.yml
@@ -32,12 +32,22 @@ jobs:
           repository: ${{ github.event.workflow_run.repository.full_name }}
           run-id: ${{ github.event.workflow_run.id }}
 
+      # Temporary allowlist of storage providers that have proven reliable during launch.
+      # This exists to paper over early stability issues while the wider provider ecosystem
+      # catches up. Remove once automatic provider discovery is trustworthy again.
+      # Having a FilOz-approved set of SPs onchain is happening in https://github.com/FilOzone/filecoin-services/issues/291
+      # This PROVIDER_ID set here will be used by the upload action below to override provider selection.
+      - name: Select random known good provider
+        run: |
+          known_good_provider_ids=(2 8 16)
+          selected_provider_id=${known_good_provider_ids[$RANDOM % ${#known_good_provider_ids[@]}]}
+          echo "PROVIDER_ID=$selected_provider_id" >> $GITHUB_ENV
+          echo "Selected known good provider ID: $selected_provider_id"
+
       # Upload to Filecoin using the downloaded build artifacts
       # The action will create a CAR file from the downloaded artifacts and upload to Filecoin
       - name: Upload to Filecoin
         uses: filecoin-project/filecoin-pin/upload-action@master
-        env:
-          PROVIDER_ID: 2
         with:
           path: dist  # Path to the downloaded build artifacts
           walletPrivateKey: ${{ secrets.WALLET_PRIVATE_KEY }}


### PR DESCRIPTION
Added a step to select a random known good provider for Filecoin uploads.

Also renamed the workflow file to `filecoin-pin-upload.yml`