### PR TITLE
[UXIT-3464] Add compact Upload component

### DIFF
--- a/src/components/upload/drag-n-drop.tsx
+++ b/src/components/upload/drag-n-drop.tsx
@@ -1,5 +1,6 @@
 import { Root } from '@radix-ui/react-form'
 import { useState } from 'react'
+import { MAX_FILE_SIZE } from '@/constants/files.ts'
 import { FilePicker } from '../file-picker/index.tsx'
 import { ButtonBase as Button } from '../ui/button/button-base.tsx'
 
@@ -32,7 +33,7 @@ export default function DragNDrop({ onFileSelected, onUpload, isUploading }: Dra
     <Root className="space-y-6" onSubmit={(e) => e.preventDefault()}>
       <FilePicker
         file={file}
-        maxSize={200_000_000}
+        maxSize={MAX_FILE_SIZE}
         onChange={(file) => {
           setFile(file)
           if (file && onFileSelected) {

--- a/src/components/upload/upload-button.tsx
+++ b/src/components/upload/upload-button.tsx
@@ -1,9 +1,9 @@
-import { Root, FormControl, FormField, FormMessage } from '@radix-ui/react-form'
-import { useRef, useState } from 'react'
+import { FormControl, FormField, FormMessage, Root } from '@radix-ui/react-form'
 import { PlusIcon } from 'lucide-react'
-
-import { ButtonBase as Button } from '../ui/button/button-base.tsx'
+import { useRef, useState } from 'react'
+import { MAX_FILE_SIZE } from '@/constants/files.ts'
 import { formatFileSize } from '@/utils/format-file-size.ts'
+import { ButtonBase as Button } from '../ui/button/button-base.tsx'
 
 interface UploadButtonProps {
   onUpload: (file: File) => void
@@ -16,19 +16,18 @@ export function UploadButton({
   onUpload,
   isUploading = false,
   accept = ['*'],
-  maxSize = 200_000_000,
+  maxSize = MAX_FILE_SIZE,
 }: UploadButtonProps) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [error, setError] = useState<string | null>(null)
 
-  const handleButtonClick = () => {
+  function handleButtonClick() {
     fileInputRef.current?.click()
   }
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (file) {
-      onUpload(file)
       if (file.size > maxSize) {
         setError(`File is too large. Maximum size is ${formatFileSize(maxSize)}.`)
         if (fileInputRef.current) fileInputRef.current.value = ''
@@ -42,7 +41,7 @@ export function UploadButton({
   }
 
   return (
-    <Root className="inline-flex flex-col gap-2" onSubmit={(e) => e.preventDefault()}>
+    <Root className="flex flex-col gap-2 items-end" onSubmit={(e) => e.preventDefault()}>
       <FormField name="file">
         <FormControl asChild>
           <input
@@ -55,15 +54,27 @@ export function UploadButton({
           />
         </FormControl>
       </FormField>
-      <Button disabled={isUploading} loading={isUploading} onClick={handleButtonClick} type="button" variant="primary">
-        <div className="flex items-center gap-2">
-          <PlusIcon size={20} />
-          <span>Add file</span>
-        </div>
-      </Button>
-      <FormField name="file">
-        <FormMessage className="text-sm text-red-500 mt-1">{error}</FormMessage>
-      </FormField>
+      <div className="w-content">
+        <Button
+          disabled={isUploading}
+          loading={isUploading}
+          onClick={handleButtonClick}
+          type="button"
+          variant="primary"
+        >
+          <div className="flex items-center gap-2">
+            <PlusIcon size={20} />
+            <span>Add file</span>
+          </div>
+        </Button>
+      </div>
+      <div className="h-3">
+        {error && (
+          <FormField name="file">
+            <FormMessage className="text-sm text-red-500 mt-1 break-words max-w-full">{error}</FormMessage>
+          </FormField>
+        )}
+      </div>
     </Root>
   )
 }

--- a/src/constants/files.ts
+++ b/src/constants/files.ts
@@ -1,0 +1,1 @@
+export const MAX_FILE_SIZE = 200_000_000


### PR DESCRIPTION
This commit introduces a new UploadButton component that allows users to upload files with error handling for file size limits. The component utilizes Radix UI for form control and includes a button with a loading state during uploads. It also provides user feedback for file size errors.

https://github.com/user-attachments/assets/b6c5f7ef-a839-408b-8a9b-7f2891e72c72

