### PR TITLE
fix: upload can be clicked before synapse is ready

### DIFF
--- a/src/hooks/use-filecoin-upload.ts
+++ b/src/hooks/use-filecoin-upload.ts
@@ -60,6 +60,7 @@ export const useFilecoinUpload = () => {
   // even if the dataset is initialized after the callback is created
   const storageContextRef = useWaitableRef(storageContext)
   const providerInfoRef = useWaitableRef(providerInfo)
+  const synapseRef = useWaitableRef(synapse)
 
   const [uploadState, setUploadState] = useState<UploadState>({
     isUploading: false,
@@ -107,9 +108,7 @@ export const useFilecoinUpload = () => {
         // Step 2: Check readiness
         updateStepState('checking-readiness', { status: 'in-progress', progress: 0 })
 
-        if (!synapse) {
-          throw new Error('Synapse client not initialized. Please check your configuration.')
-        }
+        const synapse = await synapseRef.wait()
         updateStepState('checking-readiness', { progress: 50 })
 
         // validate that we can actually upload the car, passing the autoConfigureAllowances flag to true to automatically configure allowances if needed.


### PR DESCRIPTION
related to https://github.com/filecoin-project/filecoin-pin-website/issues/104.. but when you go SUPER fast, synapse isn't ready and it would still fail.. but synapse SHOULD be ready or become ready pretty quick.. this fixes that with the new `useWaitableRef` 