### PR TITLE
[UXIT-3670] UI Fixes

### DIFF
--- a/src/components/layout/sidebar-layout.tsx
+++ b/src/components/layout/sidebar-layout.tsx
@@ -29,7 +29,7 @@ export function SidebarLayout({ children, sidebar, header }: SidebarLayoutProps)
       </aside>
 
       {/* Main content */}
-      <main className="overflow-y-auto lg:border-l lg:border-zinc-800 px-10 lg:px-15 py-10">{children}</main>
+      <main className="overflow-y-auto lg:border-l lg:border-zinc-800 px-6 lg:px-15 py-6">{children}</main>
     </div>
   )
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -33,19 +33,20 @@ function CardHeader({ title, status, estimatedTime, withSpinner }: CardHeaderPro
   const showSpinner = isInProgress && withSpinner
 
   return (
-    <div className="flex items-center justify-between gap-2">
-      <div className="flex items-center gap-3">
-        {showSpinner && <Spinner size="sm" />}
-        <Heading tag="h4">{title}</Heading>
-      </div>
+    <div className="flex flex-col gap-2 items-start">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-3">
+          {showSpinner && <Spinner size="sm" />}
+          <Heading tag="h4">{title}</Heading>
+        </div>
 
+        <div hidden={isInProgress}>
+          <BadgeStatus status={status} />
+        </div>
+      </div>
       <span aria-live="polite" className="text-sm text-right text-zinc-400" hidden={!isInProgress}>
         {estimatedTime}
       </span>
-
-      <div hidden={isInProgress}>
-        <BadgeStatus status={status} />
-      </div>
     </div>
   )
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -18,7 +18,7 @@ function Dialog({ content }: DialogProps) {
       </RadixDialog.Trigger>
       <RadixDialog.Portal>
         <RadixDialog.Overlay className="fixed inset-0 bg-black/40 animate-in fade-in-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-        <RadixDialog.Content className="fixed flex flex-col items-end gap-6 top-1/2 bg-(--color-black) border border-zinc-700 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[90vw] max-w-[500px] max-h-[85vh] p-6 pt-16 rounded-lg  shadow-lg animate-in fade-in-0 zoom-in-95 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 focus:outline-none">
+        <RadixDialog.Content className="overflow-auto fixed flex flex-col items-end gap-6 top-1/2 bg-(--color-black) border border-zinc-700 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[90vw] max-w-[500px] max-h-[85vh] p-6 pt-16 rounded-lg  shadow-lg animate-in fade-in-0 zoom-in-95 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 focus:outline-none">
           {content}
           <RadixDialog.Close asChild>
             <button

--- a/src/components/upload/upload-completed.tsx
+++ b/src/components/upload/upload-completed.tsx
@@ -107,9 +107,8 @@ function UploadCompleted({ cid, fileName, pieceCid, datasetId }: UploadCompleted
         <Card.InfoRow
           subtitle={<TextLink href={getProviderExplorerLink(providerAddress)}>{providerName}</TextLink>}
           title="Provider"
-        >
-          <ButtonLink href={getDatasetExplorerLink(datasetIdOrDefault)}>View proofs</ButtonLink>
-        </Card.InfoRow>
+        ></Card.InfoRow>
+        <ButtonLink href={getDatasetExplorerLink(datasetIdOrDefault)}>View proofs</ButtonLink>
       </Card.Wrapper>
     </>
   )


### PR DESCRIPTION
## Description

* Updated sidebar layout padding on mobile to be 24px
* Added `overflow-auto` to the `Dialog` component so it's visible on scroll
* Refactored `CardHeader` to have the step title in one line and the time estimation in another line
* Modified `CardRow` to have View Proofs button in another line

## Screenshot
<img width="413" height="664" alt="Screenshot 2025-11-14 at 15 50 09" src="https://github.com/user-attachments/assets/1f35e8a9-5850-4bab-a7f0-becc38876ed6" />
<img width="413" height="573" alt="Screenshot 2025-11-14 at 15 53 54" src="https://github.com/user-attachments/assets/e0e890dd-9a6f-4038-9c25-47577765f860" />

https://github.com/user-attachments/assets/ce91d45e-d818-499d-a16f-6cddf1638282

