### PR TITLE
fix pass private key as config

### DIFF
--- a/src/lib/filecoin-pin/config.ts
+++ b/src/lib/filecoin-pin/config.ts
@@ -11,17 +11,11 @@ const DEFAULT_WALLET_ADDRESS = '0x44f08D1beFe61255b3C3A349C392C560FA333759'
 const DEFAULT_SESSION_KEY = '0xca3c92749c4c31beb64ea4334a719b813af1b54b8449a12c81d583018a252af8'
 
 const privateKey = normalizeEnvValue(import.meta.env.VITE_FILECOIN_PRIVATE_KEY)
-const walletAddress = normalizeEnvValue(import.meta.env.VITE_WALLET_ADDRESS) ?? DEFAULT_WALLET_ADDRESS
-const sessionKey = normalizeEnvValue(import.meta.env.VITE_SESSION_KEY) ?? DEFAULT_SESSION_KEY
+const walletAddress = normalizeEnvValue(import.meta.env.VITE_WALLET_ADDRESS)
+const sessionKey = normalizeEnvValue(import.meta.env.VITE_SESSION_KEY)
 
 const hasStandardAuth = privateKey != null
 const hasSessionKeyAuth = walletAddress != null && sessionKey != null
-
-if (!hasStandardAuth && !hasSessionKeyAuth) {
-  throw new Error(
-    'Authentication required: provide either VITE_FILECOIN_PRIVATE_KEY or (VITE_WALLET_ADDRESS + VITE_SESSION_KEY)'
-  )
-}
 
 if (hasStandardAuth && hasSessionKeyAuth) {
   throw new Error(
@@ -29,10 +23,15 @@ if (hasStandardAuth && hasSessionKeyAuth) {
   )
 }
 
+const auth = hasStandardAuth
+  ? { privateKey }
+  : {
+      walletAddress: walletAddress ?? DEFAULT_WALLET_ADDRESS,
+      sessionKey: sessionKey ?? DEFAULT_SESSION_KEY,
+    }
+
 export const filecoinPinConfig: SynapseSetupConfig = {
-  privateKey: privateKey,
-  walletAddress: walletAddress,
-  sessionKey: sessionKey,
+  ...auth,
   rpcUrl: normalizeEnvValue(import.meta.env.VITE_FILECOIN_RPC_URL),
   warmStorageAddress: normalizeEnvValue(import.meta.env.VITE_WARM_STORAGE_ADDRESS),
 }


### PR DESCRIPTION
Before this patch, when you pass a private key, you get this error, because the config always defaults empty wallet address and session key to default values:

> Conflicting authentication: provide either VITE_FILECOIN_PRIVATE_KEY or (VITE_WALLET_ADDRESS + VITE_SESSION_KEY), not both