### PR TITLE
test: try ipfs-deploy-action fork w/ filecoin-pin CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
   # Call the Filecoin upload workflow
   # This runs after test completes and reuses the build artifacts
   filecoin-upload:
-    needs: test
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/filecoin-pin-upload.yml
+++ b/.github/workflows/filecoin-pin-upload.yml
@@ -18,12 +18,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Download the build artifacts from the calling workflow
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          name: site-dist
-          path: dist
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Build site
+        run: npm run build
 
       # Upload to Filecoin via ipfs-deploy-action fork (testing filecoin-pin CLI integration)
       - name: Upload to Filecoin

--- a/.github/workflows/filecoin-pin-upload.yml
+++ b/.github/workflows/filecoin-pin-upload.yml
@@ -25,13 +25,14 @@ jobs:
           name: site-dist
           path: dist
 
-      # Upload to Filecoin using the downloaded build artifacts
-      # The action will create a CAR file from the downloaded artifacts and upload to Filecoin
+      # Upload to Filecoin via ipfs-deploy-action fork (testing filecoin-pin CLI integration)
       - name: Upload to Filecoin
-        uses: filecoin-project/filecoin-pin/upload-action@master
+        uses: SgtPooki/ipfs-deploy-action@feat/filecoin-support
         with:
-          path: dist  # Path to the downloaded build artifacts
-          walletPrivateKey: ${{ secrets.WALLET_PRIVATE_KEY }}
-          network: calibration
-          minStorageDays: "30"
-          filecoinPayBalanceLimit: "0.25"
+          path-to-deploy: dist
+          filecoin-wallet-private-key: ${{ secrets.WALLET_PRIVATE_KEY }}
+          filecoin-network: calibration
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          set-github-status: 'false'
+          set-pr-comment: 'false'
+          upload-car-artifact: 'false'


### PR DESCRIPTION
**Do not merge — testing-only.**

Swaps the Filecoin upload step from `filecoin-project/filecoin-pin/upload-action@master` to `SgtPooki/ipfs-deploy-action@feat/filecoin-support` to validate the new CLI-based Filecoin upload path in the forked `ipfs-deploy-action`.

Once the workflow run succeeds against this PR, the upstream PR will be opened against `ipshipyard/ipfs-deploy-action`.

Source branch: https://github.com/SgtPooki/ipfs-deploy-action/tree/feat/filecoin-support