### PR TITLE
feat(storybook): add UploadFlowWalkthrough story for multi-copy upload UI

### DIFF
--- a/src/components/upload/upload-completed.tsx
+++ b/src/components/upload/upload-completed.tsx
@@ -33,6 +33,12 @@ interface UploadCompletedProps {
   serviceURLs?: string[]
 }
 
+function resolveDatasetIds(datasetIds: string[] | undefined, fallback: string): string[] {
+  if (datasetIds != null && datasetIds.length > 0) return datasetIds
+  if (fallback) return [fallback]
+  return []
+}
+
 function UploadCompleted({
   cid,
   fileName,
@@ -73,8 +79,7 @@ function UploadCompleted({
   const fallbackDatasetId =
     dataSet.status === 'ready' && dataSet.dataSetIds.length > 0 ? String(dataSet.dataSetIds[0]) : ''
   const datasetIdOrDefault = datasetId || fallbackDatasetId
-  const resolvedDatasetIds =
-    datasetIds && datasetIds.length > 0 ? datasetIds : datasetIdOrDefault ? [datasetIdOrDefault] : []
+  const resolvedDatasetIds = resolveDatasetIds(datasetIds, datasetIdOrDefault)
 
   // Build per-copy provider rows aligned with resolvedDatasetIds
   const copyRows = resolvedDatasetIds.map((dsId, i) => ({

--- a/src/components/upload/upload-flow.stories.tsx
+++ b/src/components/upload/upload-flow.stories.tsx
@@ -1,0 +1,383 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { FilecoinPinContext, type FilecoinPinContextValue } from '../../context/filecoin-pin-provider.tsx'
+import type { StepState } from '../../types/upload/step.ts'
+import { ButtonBase } from '../ui/button/button-base.tsx'
+import { UploadStatus } from './upload-status.tsx'
+
+/**
+ * Mock FilecoinPinContext value. UploadCompleted reads `dataSet` to derive
+ * a fallback datasetId; we always pass datasetId explicitly so the hook's
+ * value is harmless.
+ */
+const MOCK_CONTEXT: FilecoinPinContextValue = {
+  wallet: { status: 'idle' },
+  refreshWallet: async () => {
+    /* noop */
+  },
+  synapse: null,
+  dataSet: { status: 'idle' },
+  checkIfDatasetExists: async () => [],
+  addDataSetId: () => {
+    /* noop */
+  },
+}
+
+const FILE_NAME = 'demo-data.car'
+const FILE_SIZE = '4.20 MB'
+const ROOT_CID = 'bafybeigoflpi43gpwuf2i2srflxdkgtsxmvwqcrfruaceuju3kmlzoigzm'
+const PIECE_CID = 'baga6ea4seaqfoztqwvslmx6ptxvzopg4g6n5do2br36exlo6ylsyu7akdcm5sdy'
+const TX_HASHES = [
+  '0xf85d7c38321ce4a4c3d0fac4a5347f20a2f9596da5120df28b1190ac0948ad77',
+  '0xfb3d2a9b2aa5f83aca1f8235f8c5e215aa2cc1cb8e7c7a57f8b7e5d49f74e51d',
+  '0x4b7d0124e5a1d2c398cba4fb3e8adf7a1c2ccc7ab9ca5559a53fba6d04d332ef',
+]
+const DATASET_IDS = ['101', '202', '303']
+const PROVIDER_IDS = ['9', '12', '17']
+const PROVIDER_NAMES = ['Hot Cargo Storage', 'Iron Vault SP', 'Cumulus Provider']
+const SERVICE_URLS = [
+  'https://pdp.hotcargo.example/sp',
+  'https://pdp.ironvault.example/sp',
+  'https://pdp.cumulus.example/sp',
+]
+
+type FailureMode = 'none' | 'replicating-failed' | 'ipni-failed'
+
+interface FlowConfig {
+  copies: number
+  failureMode: FailureMode
+  tickMs: number
+  network: string
+}
+
+const INITIAL_STEPS: StepState[] = [
+  { step: 'creating-car', progress: 0, status: 'pending' },
+  { step: 'checking-readiness', progress: 0, status: 'pending' },
+  { step: 'uploading-car', progress: 0, status: 'pending' },
+  { step: 'replicating', progress: 0, status: 'pending' },
+  { step: 'announcing-cids', progress: 0, status: 'pending' },
+  { step: 'finalizing-transaction', progress: 0, status: 'pending' },
+]
+
+interface FlowState {
+  stepStates: StepState[]
+  cid?: string
+  pieceCid?: string
+  transactionHashes: string[]
+  expectedCopies: number
+  confirmedCopies: number
+  copyCount?: number
+  datasetIds?: string[]
+  datasetId?: string
+  providerIds?: string[]
+  providerNames?: string[]
+  serviceURLs?: string[]
+  network?: string
+}
+
+const INITIAL_STATE: FlowState = {
+  stepStates: INITIAL_STEPS,
+  transactionHashes: [],
+  expectedCopies: 0,
+  confirmedCopies: 0,
+}
+
+/**
+ * Sequence of state mutations representing a real upload flow.
+ * Each tick is one `tickMs` interval. Pure data — exercises real
+ * UploadStatus props pipeline without coupling to SDK.
+ */
+function buildScript(config: FlowConfig): Array<(s: FlowState) => FlowState> {
+  const script: Array<(s: FlowState) => FlowState> = []
+  const { copies, failureMode, network } = config
+
+  // Set network early so finalizing-card title/links pick it up
+  script.push((s) => ({ ...s, network }))
+
+  // creating-car: 0 -> 100
+  for (const p of [25, 50, 75, 100]) {
+    script.push((s) => ({
+      ...s,
+      stepStates: setStep(s.stepStates, 'creating-car', {
+        status: p === 100 ? 'completed' : 'in-progress',
+        progress: p,
+      }),
+      cid: p === 100 ? ROOT_CID : s.cid,
+    }))
+  }
+
+  // checking-readiness + uploading-car start
+  script.push((s) => ({
+    ...s,
+    stepStates: setStep(
+      setStep(s.stepStates, 'checking-readiness', { status: 'in-progress', progress: 50 }),
+      'uploading-car',
+      {
+        status: 'in-progress',
+        progress: 0,
+      }
+    ),
+  }))
+  script.push((s) => ({
+    ...s,
+    stepStates: setStep(
+      setStep(s.stepStates, 'checking-readiness', { status: 'completed', progress: 100 }),
+      'uploading-car',
+      {
+        status: 'in-progress',
+        progress: 50,
+      }
+    ),
+  }))
+
+  // onStored: uploading-car complete, replicating in-progress, pieceCid available
+  script.push((s) => ({
+    ...s,
+    pieceCid: PIECE_CID,
+    stepStates: setStep(setStep(s.stepStates, 'uploading-car', { status: 'completed', progress: 100 }), 'replicating', {
+      status: 'in-progress',
+      progress: 0,
+    }),
+  }))
+
+  // onCopyComplete or onCopyFailed
+  if (copies >= 2) {
+    if (failureMode === 'replicating-failed') {
+      script.push((s) => ({
+        ...s,
+        stepStates: setStep(
+          setStep(s.stepStates, 'replicating', {
+            status: 'error',
+            progress: 0,
+            error: 'Secondary copy failed, file stored with reduced redundancy',
+          }),
+          'announcing-cids',
+          { status: 'in-progress', progress: 0 }
+        ),
+      }))
+    } else {
+      script.push((s) => ({
+        ...s,
+        stepStates: setStep(
+          setStep(s.stepStates, 'replicating', { status: 'completed', progress: 100 }),
+          'announcing-cids',
+          {
+            status: 'in-progress',
+            progress: 0,
+          }
+        ),
+      }))
+    }
+  } else {
+    // single-copy fallback path: no onCopyComplete; replicating done via onPiecesAdded fallback later
+    script.push((s) => ({
+      ...s,
+      stepStates: setStep(s.stepStates, 'announcing-cids', { status: 'in-progress', progress: 0 }),
+    }))
+  }
+
+  // onPiecesAdded × N (one per copy attempted)
+  const piecesAddedCount = failureMode === 'replicating-failed' ? 1 : copies
+  for (let i = 0; i < piecesAddedCount; i++) {
+    script.push((s) => {
+      const newHashes = [...s.transactionHashes, TX_HASHES[i] ?? TX_HASHES[0]]
+      const newExpected = s.expectedCopies + 1
+      const stepStates = setStep(
+        setStep(
+          s.stepStates.map((step) =>
+            step.step === 'replicating' && step.status === 'in-progress'
+              ? { ...step, status: 'completed' as const, progress: 100 }
+              : step
+          ),
+          'finalizing-transaction',
+          { status: 'in-progress', progress: 0 }
+        ),
+        'finalizing-transaction',
+        { status: 'in-progress', progress: 0 }
+      )
+      return { ...s, transactionHashes: newHashes, expectedCopies: newExpected, stepStates }
+    })
+  }
+
+  // onPiecesConfirmed × N — accumulate per-copy data so the completed view
+  // already has the full picture once isUploadSuccessful flips on.
+  for (let i = 0; i < piecesAddedCount; i++) {
+    script.push((s) => {
+      const newConfirmed = s.confirmedCopies + 1
+      const allConfirmed = newConfirmed >= s.expectedCopies && s.expectedCopies > 0
+      const progress = Math.round((newConfirmed / Math.max(s.expectedCopies, 1)) * 100)
+      const stepStates = setStep(s.stepStates, 'finalizing-transaction', {
+        status: allConfirmed ? 'completed' : 'in-progress',
+        progress,
+      })
+      const datasetIdForCopy = DATASET_IDS[i] ?? DATASET_IDS[0]
+      const providerIdForCopy = PROVIDER_IDS[i] ?? PROVIDER_IDS[0]
+      const providerNameForCopy = PROVIDER_NAMES[i] ?? PROVIDER_NAMES[0]
+      const serviceUrlForCopy = SERVICE_URLS[i] ?? SERVICE_URLS[0]
+      return {
+        ...s,
+        confirmedCopies: newConfirmed,
+        stepStates,
+        datasetId: s.datasetId ?? datasetIdForCopy,
+        datasetIds: [...(s.datasetIds ?? []), datasetIdForCopy],
+        providerIds: [...(s.providerIds ?? []), providerIdForCopy],
+        providerNames: [...(s.providerNames ?? []), providerNameForCopy],
+        serviceURLs: [...(s.serviceURLs ?? []), serviceUrlForCopy],
+        copyCount: newConfirmed,
+      }
+    })
+  }
+
+  // IPNI announce result
+  if (failureMode === 'ipni-failed') {
+    script.push((s) => ({
+      ...s,
+      stepStates: setStep(s.stepStates, 'announcing-cids', {
+        status: 'error',
+        progress: 0,
+        error: 'Could not verify IPNI announcement',
+      }),
+    }))
+  } else {
+    script.push((s) => ({
+      ...s,
+      stepStates: setStep(s.stepStates, 'announcing-cids', { status: 'completed', progress: 100 }),
+    }))
+  }
+
+  return script
+}
+
+function setStep(steps: StepState[], name: StepState['step'], updates: Partial<StepState>): StepState[] {
+  return steps.map((s) => (s.step === name ? ({ ...s, ...updates } as StepState) : s))
+}
+
+interface WalkthroughProps {
+  copies: 1 | 2 | 3
+  failureMode: FailureMode
+  autoPlay: boolean
+  tickMs: number
+  network: 'calibration' | 'mainnet'
+}
+
+function Walkthrough({ copies, failureMode, autoPlay, tickMs, network }: WalkthroughProps) {
+  const config = useMemo<FlowConfig>(
+    () => ({ copies, failureMode, tickMs, network }),
+    [copies, failureMode, tickMs, network]
+  )
+  const script = useMemo(() => buildScript(config), [config])
+
+  const [state, setState] = useState<FlowState>(INITIAL_STATE)
+  const [tick, setTick] = useState(0)
+  const [running, setRunning] = useState(autoPlay)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const advance = useCallback(() => {
+    setTick((t) => {
+      if (t >= script.length) return t
+      setState((s) => script[t](s))
+      return t + 1
+    })
+  }, [script])
+
+  const reset = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    setState(INITIAL_STATE)
+    setTick(0)
+    setRunning(autoPlay)
+  }, [autoPlay])
+
+  // Reset on config change
+  useEffect(() => {
+    reset()
+  }, [reset])
+
+  // Auto-play timer
+  useEffect(() => {
+    if (!running || tick >= script.length) return
+    timerRef.current = setTimeout(advance, tickMs)
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [running, tick, script.length, advance, tickMs])
+
+  const done = tick >= script.length
+
+  return (
+    <FilecoinPinContext.Provider value={MOCK_CONTEXT}>
+      <div className="space-y-4 max-w-2xl">
+        <div className="flex gap-2 items-center text-sm text-zinc-300">
+          <ButtonBase onClick={() => setRunning((r) => !r)}>{running ? 'Pause' : 'Play'}</ButtonBase>
+          <ButtonBase onClick={advance}>Step</ButtonBase>
+          <ButtonBase onClick={reset}>Reset</ButtonBase>
+          <span>
+            Tick {tick} / {script.length} {done ? '(done)' : ''}
+          </span>
+        </div>
+        <UploadStatus
+          cid={state.cid}
+          confirmedCopies={state.confirmedCopies}
+          copyCount={state.copyCount}
+          datasetId={state.datasetId}
+          datasetIds={state.datasetIds}
+          expectedCopies={state.expectedCopies}
+          fileName={FILE_NAME}
+          fileSize={FILE_SIZE}
+          isExpanded={true}
+          pieceCid={state.pieceCid}
+          providerIds={state.providerIds}
+          providerNames={state.providerNames}
+          serviceURLs={state.serviceURLs}
+          stepStates={state.stepStates}
+          transactionHash={state.transactionHashes[0] ?? ''}
+          transactionHashes={state.transactionHashes}
+          uploadNetwork={state.network}
+        />
+      </div>
+    </FilecoinPinContext.Provider>
+  )
+}
+
+const meta = {
+  title: 'Upload/UploadFlowWalkthrough',
+  component: Walkthrough,
+  parameters: { layout: 'padded' },
+  argTypes: {
+    copies: { control: { type: 'inline-radio' }, options: [1, 2, 3] },
+    failureMode: { control: { type: 'inline-radio' }, options: ['none', 'replicating-failed', 'ipni-failed'] },
+    autoPlay: { control: 'boolean' },
+    tickMs: { control: { type: 'number', min: 100, max: 3000, step: 100 } },
+    network: { control: { type: 'inline-radio' }, options: ['calibration', 'mainnet'] },
+  },
+} satisfies Meta<typeof Walkthrough>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const HappyPath2x: Story = {
+  args: { copies: 2, failureMode: 'none', autoPlay: true, tickMs: 600, network: 'calibration' },
+}
+
+export const HappyPath3x: Story = {
+  args: { copies: 3, failureMode: 'none', autoPlay: true, tickMs: 600, network: 'calibration' },
+}
+
+export const ReplicationDegraded: Story = {
+  args: { copies: 2, failureMode: 'replicating-failed', autoPlay: true, tickMs: 600, network: 'calibration' },
+}
+
+export const IpniAnnounceFailed: Story = {
+  args: { copies: 2, failureMode: 'ipni-failed', autoPlay: true, tickMs: 600, network: 'calibration' },
+}
+
+export const SingleCopy: Story = {
+  args: { copies: 1, failureMode: 'none', autoPlay: true, tickMs: 600, network: 'calibration' },
+}
+
+export const ManualStep: Story = {
+  args: { copies: 2, failureMode: 'none', autoPlay: false, tickMs: 600, network: 'calibration' },
+}
+
+export const Mainnet: Story = {
+  args: { copies: 2, failureMode: 'none', autoPlay: true, tickMs: 600, network: 'mainnet' },
+}

--- a/src/components/upload/upload-flow.stories.tsx
+++ b/src/components/upload/upload-flow.stories.tsx
@@ -21,6 +21,7 @@ const MOCK_CONTEXT: FilecoinPinContextValue = {
   addDataSetId: () => {
     /* noop */
   },
+  debugParams: { providerId: null, dataSetId: null },
 }
 
 const FILE_NAME = 'demo-data.car'

--- a/src/components/upload/upload-flow.stories.tsx
+++ b/src/components/upload/upload-flow.stories.tsx
@@ -183,14 +183,10 @@ function buildScript(config: FlowConfig): Array<(s: FlowState) => FlowState> {
       const newHashes = [...s.transactionHashes, TX_HASHES[i] ?? TX_HASHES[0]]
       const newExpected = s.expectedCopies + 1
       const stepStates = setStep(
-        setStep(
-          s.stepStates.map((step) =>
-            step.step === 'replicating' && step.status === 'in-progress'
-              ? { ...step, status: 'completed' as const, progress: 100 }
-              : step
-          ),
-          'finalizing-transaction',
-          { status: 'in-progress', progress: 0 }
+        s.stepStates.map((step) =>
+          step.step === 'replicating' && step.status === 'in-progress'
+            ? { ...step, status: 'completed' as const, progress: 100 }
+            : step
         ),
         'finalizing-transaction',
         { status: 'in-progress', progress: 0 }
@@ -290,7 +286,7 @@ function Walkthrough({ copies, failureMode, autoPlay, tickMs, network }: Walkthr
   // Reset on config change
   useEffect(() => {
     reset()
-  }, [reset])
+  }, [reset, script])
 
   // Auto-play timer
   useEffect(() => {

--- a/src/components/upload/upload-flow.stories.tsx
+++ b/src/components/upload/upload-flow.stories.tsx
@@ -283,7 +283,7 @@ function Walkthrough({ copies, failureMode, autoPlay, tickMs, network }: Walkthr
     setRunning(autoPlay)
   }, [autoPlay])
 
-  // Reset on config change
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `reset` identity only changes with `autoPlay`; `script` is needed in deps so config changes (copies/failureMode/tickMs/network) re-trigger the reset.
   useEffect(() => {
     reset()
   }, [reset, script])

--- a/src/lib/filecoin-pin/config.ts
+++ b/src/lib/filecoin-pin/config.ts
@@ -12,17 +12,21 @@ const DEFAULT_WALLET_ADDRESS: Hex = '0x44f08D1beFe61255b3C3A349C392C560FA333759'
 const DEFAULT_SESSION_KEY: Hex = '0xca3c92749c4c31beb64ea4334a719b813af1b54b8449a12c81d583018a252af8'
 
 const privateKey = normalizeEnvValue(import.meta.env.VITE_FILECOIN_PRIVATE_KEY) as Hex | undefined
-const walletAddress = (normalizeEnvValue(import.meta.env.VITE_WALLET_ADDRESS) ?? DEFAULT_WALLET_ADDRESS) as Hex
-const sessionKey = (normalizeEnvValue(import.meta.env.VITE_SESSION_KEY) ?? DEFAULT_SESSION_KEY) as Hex
+const envWalletAddress = normalizeEnvValue(import.meta.env.VITE_WALLET_ADDRESS) as Hex | undefined
+const envSessionKey = normalizeEnvValue(import.meta.env.VITE_SESSION_KEY) as Hex | undefined
 
-const hasStandardAuth = privateKey != null
-const hasSessionKeyAuth = walletAddress != null && sessionKey != null
+// Only treat session-key auth as user-supplied when at least one of the env vars is set.
+// Hardcoded defaults must not trigger the conflict check when a private key is provided.
+const hasUserSessionKeyAuth = envWalletAddress != null || envSessionKey != null
 
-if (hasStandardAuth && hasSessionKeyAuth) {
+if (privateKey != null && hasUserSessionKeyAuth) {
   throw new Error(
     'Conflicting authentication: provide either VITE_FILECOIN_PRIVATE_KEY or (VITE_WALLET_ADDRESS + VITE_SESSION_KEY), not both'
   )
 }
+
+const walletAddress = (envWalletAddress ?? DEFAULT_WALLET_ADDRESS) as Hex
+const sessionKey = (envSessionKey ?? DEFAULT_SESSION_KEY) as Hex
 
 export const filecoinPinConfig: SynapseSetupConfig = privateKey
   ? { privateKey, rpcUrl: normalizeEnvValue(import.meta.env.VITE_FILECOIN_RPC_URL) }


### PR DESCRIPTION
Stacks on #154.

## Summary
- Adds `src/components/upload/upload-flow.stories.tsx` — a scripted walkthrough that drives `UploadStatus` through every state of the multi-copy upload pipeline.
- Reviewers can see all upload states without a wallet, private key, or live SDK.

## Stories
- **HappyPath2x** — auto-play, ends with `2x replicated` badge
- **HappyPath3x** — three copies, three tx hashes
- **ReplicationDegraded** — `onCopyFailed` path, yellow `1 copy` badge
- **IpniAnnounceFailed** — IPNI warning, upload still succeeds
- **SingleCopy** — copies=1, exercises the `onPiecesAdded` fallback for completing `replicating`
- **ManualStep** — autoPlay=false; reviewer drives Play/Step/Reset buttons

## How it works
Pure data — array of state mutators, one per "tick". Each mutator mirrors a real SDK event from `use-filecoin-upload.ts` (onStored / onCopyComplete / onCopyFailed / onPiecesAdded × N / onPiecesConfirmed × N / IPNI result). No SDK or context coupling beyond a mock `FilecoinPinContext.Provider`.

## Follow-up
A separate tracking issue will be opened to extract the upload state machine from `use-filecoin-upload.ts` into a pure reducer so the story drives the real reducer (and unit tests can cover it).

## Test plan
- [ ] Storybook boots: `npm run storybook`
- [ ] Each story renders without console errors
- [ ] HappyPath2x ends in `2x replicated` badge with two tx hashes and two `Data Sets` listed
- [ ] ReplicationDegraded shows red error on `replicating` step + yellow `1 copy` badge in completed state
- [ ] IpniAnnounceFailed shows warning on `announcing-cids` but still hits success state
- [ ] ManualStep: Play/Pause/Step/Reset all work


[2026-04-30 at 12.45.04 - White Wildcat.webm](https://github.com/user-attachments/assets/88154478-361c-4d06-b74d-b1b960b66758)
