### PR TITLE
fix: bypass synapse-sdk permission gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "filecoin-pin-website",
       "version": "0.0.0",
       "dependencies": {
+        "@filoz/synapse-core": "0.4.1",
+        "@filoz/synapse-sdk": "0.40.4",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-form": "^0.1.8",
@@ -25,7 +27,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.14",
-        "viem": "^2.0.0"
+        "viem": "^2.47.12"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.2.5",
@@ -146,9 +148,9 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -193,9 +195,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -354,9 +356,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -465,9 +467,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.13.tgz",
-      "integrity": "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.15.tgz",
+      "integrity": "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -481,20 +483,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.4.13",
-        "@biomejs/cli-darwin-x64": "2.4.13",
-        "@biomejs/cli-linux-arm64": "2.4.13",
-        "@biomejs/cli-linux-arm64-musl": "2.4.13",
-        "@biomejs/cli-linux-x64": "2.4.13",
-        "@biomejs/cli-linux-x64-musl": "2.4.13",
-        "@biomejs/cli-win32-arm64": "2.4.13",
-        "@biomejs/cli-win32-x64": "2.4.13"
+        "@biomejs/cli-darwin-arm64": "2.4.15",
+        "@biomejs/cli-darwin-x64": "2.4.15",
+        "@biomejs/cli-linux-arm64": "2.4.15",
+        "@biomejs/cli-linux-arm64-musl": "2.4.15",
+        "@biomejs/cli-linux-x64": "2.4.15",
+        "@biomejs/cli-linux-x64-musl": "2.4.15",
+        "@biomejs/cli-win32-arm64": "2.4.15",
+        "@biomejs/cli-win32-x64": "2.4.15"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.13.tgz",
-      "integrity": "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.15.tgz",
+      "integrity": "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==",
       "cpu": [
         "arm64"
       ],
@@ -509,9 +511,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.13.tgz",
-      "integrity": "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.15.tgz",
+      "integrity": "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==",
       "cpu": [
         "x64"
       ],
@@ -526,9 +528,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.13.tgz",
-      "integrity": "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.15.tgz",
+      "integrity": "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==",
       "cpu": [
         "arm64"
       ],
@@ -543,9 +545,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.13.tgz",
-      "integrity": "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.15.tgz",
+      "integrity": "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==",
       "cpu": [
         "arm64"
       ],
@@ -560,9 +562,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.13.tgz",
-      "integrity": "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.15.tgz",
+      "integrity": "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==",
       "cpu": [
         "x64"
       ],
@@ -577,9 +579,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.13.tgz",
-      "integrity": "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.15.tgz",
+      "integrity": "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==",
       "cpu": [
         "x64"
       ],
@@ -594,9 +596,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.13.tgz",
-      "integrity": "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.15.tgz",
+      "integrity": "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==",
       "cpu": [
         "arm64"
       ],
@@ -611,9 +613,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.13.tgz",
-      "integrity": "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.15.tgz",
+      "integrity": "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==",
       "cpu": [
         "x64"
       ],
@@ -684,17 +686,6 @@
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0",
         "wherearewe": "^2.0.1"
-      }
-    },
-    "node_modules/@chainsafe/libp2p-noise/node_modules/protons-runtime": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.6.0.tgz",
-      "integrity": "sha512-/Kde+sB9DsMFrddJT/UZWe6XqvL7SL5dbag/DBCElFKhkwDj7XKt53S+mzLyaDP5OqS0wXjV5SA572uWDaT0Hg==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "uint8-varint": "^2.0.2",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.1"
       }
     },
     "node_modules/@chainsafe/libp2p-yamux": {
@@ -1555,17 +1546,18 @@
       }
     },
     "node_modules/@filoz/synapse-core": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@filoz/synapse-core/-/synapse-core-0.3.3.tgz",
-      "integrity": "sha512-praC+AXVYhqcM0ptBIaQI5W0aVvU7uM0S1nNsqfdh8nIubz8TrWzCwM+DXVWR1VQ1/Mp2Qdl9UhGYKiZq5ZG4Q==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@filoz/synapse-core/-/synapse-core-0.4.1.tgz",
+      "integrity": "sha512-Psj2YpIxNh+nxJN0wQdYMBTQRRhq1gR/C9kosI39Kx6y+lV8ppw02c6mPeHEaa47AG3KfUqQyMb3xqurOlwraQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@web3-storage/data-segment": "^5.3.0",
         "dnum": "^2.15.0",
-        "iso-web": "^2.1.0",
+        "iso-web": "^2.2.0",
         "multiformats": "^13.4.1",
         "ox": "^0.14.0",
         "p-locate": "^7.0.0",
+        "p-queue": "^9.1.2",
         "p-some": "^7.0.0",
         "zod": "^4.3.5"
       },
@@ -1581,26 +1573,6 @@
       "dependencies": {
         "@filoz/synapse-core": "^0.4.1",
         "multiformats": "^13.4.1"
-      },
-      "peerDependencies": {
-        "viem": "2.x"
-      }
-    },
-    "node_modules/@filoz/synapse-sdk/node_modules/@filoz/synapse-core": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@filoz/synapse-core/-/synapse-core-0.4.1.tgz",
-      "integrity": "sha512-Psj2YpIxNh+nxJN0wQdYMBTQRRhq1gR/C9kosI39Kx6y+lV8ppw02c6mPeHEaa47AG3KfUqQyMb3xqurOlwraQ==",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@web3-storage/data-segment": "^5.3.0",
-        "dnum": "^2.15.0",
-        "iso-web": "^2.2.0",
-        "multiformats": "^13.4.1",
-        "ox": "^0.14.0",
-        "p-locate": "^7.0.0",
-        "p-queue": "^9.1.2",
-        "p-some": "^7.0.0",
-        "zod": "^4.3.5"
       },
       "peerDependencies": {
         "viem": "2.x"
@@ -1632,6 +1604,17 @@
         "progress-events": "^1.1.0",
         "protons-runtime": "^6.0.1",
         "race-event": "^1.6.1",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@helia/bitswap/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
         "uint8-varint": "^2.0.4",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
@@ -1779,20 +1762,26 @@
       }
     },
     "node_modules/@ipld/car": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.4.3.tgz",
-      "integrity": "sha512-+6QHy+9sLov1K28PmazHyqEmD5oDeMWa3mwxst8rt5OsP7CmEexwYDOflGSjPDOUWgHQ4WabQnBSZfXKvZ0DUw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.4.5.tgz",
+      "integrity": "sha512-t4MDTUobZ+oHZguVdviGS8WfQEgkpNwzPMAZy4/AEKZWEAcav9GWJqlyHF/O3DE7cjPgXGnlLArlrcMgC1HUgg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.7",
         "cborg": "^5.0.0",
-        "multiformats": "^13.0.0",
+        "multiformats": "^14.0.0",
         "varint": "^6.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
+    },
+    "node_modules/@ipld/car/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@ipld/dag-cbor": {
       "version": "9.2.6",
@@ -1823,17 +1812,23 @@
       }
     },
     "node_modules/@ipld/dag-pb": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.5.tgz",
-      "integrity": "sha512-w4PZ2yPqvNmlAir7/2hsCRMqny1EY5jj26iZcSgxREJexmbAc2FI21jp26MqiNdfgAxvkCnf2N/TJI18GaDNwA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.7.tgz",
+      "integrity": "sha512-/i/13trFihjWfDyXlylRwhuYjtzYjvOFw0vlRjYGnZuv7d7MOgA2lV/vRuL5RfeUajM03aZfFLdq4S7cTbbTRg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "multiformats": "^13.1.0"
+        "multiformats": "^14.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
+    },
+    "node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@ipshipyard/libp2p-auto-tls": {
       "version": "2.0.1",
@@ -1991,16 +1986,16 @@
       "license": "MIT"
     },
     "node_modules/@libp2p/autonat": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/@libp2p/autonat/-/autonat-3.0.18.tgz",
-      "integrity": "sha512-lMOCwLNOoT2/87li6ZJ/ClSCrK4REg3mK/dsUwsJxpnbqQqAtaxvwPNcUodgw2JaHSWw+dlKQ4IsTT4L45APFQ==",
+      "version": "3.0.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/autonat/-/autonat-3.0.19.tgz",
+      "integrity": "sha512-1KKZZT0y5Mt3VPzKLPeCBHXsLI0Q9i7Pieg1UuL472oNvC1kXLiQJbHaJOgLvfXXb91m5U+fK4fFSOK1RpEHXA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/interface-internal": "^3.1.3",
-        "@libp2p/peer-collections": "^7.0.18",
-        "@libp2p/peer-id": "^6.0.8",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/interface-internal": "^3.1.4",
+        "@libp2p/peer-collections": "^7.0.19",
+        "@libp2p/peer-id": "^6.0.9",
+        "@libp2p/utils": "^7.2.0",
         "@multiformats/multiaddr": "^13.0.1",
         "any-signal": "^4.1.1",
         "main-event": "^1.0.1",
@@ -2009,33 +2004,44 @@
         "uint8arraylist": "^2.4.8"
       }
     },
+    "node_modules/@libp2p/autonat/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
     "node_modules/@libp2p/bootstrap": {
-      "version": "12.0.19",
-      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-12.0.19.tgz",
-      "integrity": "sha512-wem+hzocuSKyarv/1uwj48IADdTqAxKR5oXLvvRX0Gu9pfqQBhjX78SndQkcIbhH8SsOyX5FDzmA6kI3I0MPgw==",
+      "version": "12.0.21",
+      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-12.0.21.tgz",
+      "integrity": "sha512-k2lyLYcLbK00E8myG5t1NQG/iX2wyNo4vkSQRH/B/i2Q5MSlH1CGIVBATGNm+x/Cck/+qjd3dS1HEE+QftGaWg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/interface-internal": "^3.1.3",
-        "@libp2p/peer-id": "^6.0.8",
+        "@libp2p/interface-internal": "^3.1.4",
+        "@libp2p/peer-id": "^6.0.9",
         "@multiformats/multiaddr": "^13.0.1",
         "@multiformats/multiaddr-matcher": "^3.0.1",
         "main-event": "^1.0.1"
       }
     },
     "node_modules/@libp2p/circuit-relay-v2": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/circuit-relay-v2/-/circuit-relay-v2-4.2.3.tgz",
-      "integrity": "sha512-sVn3oEqYwRwqrgbqb8/kz82elahhVKEQ556pIrRLmPGXV8ZHjpfYDAWEJwNxlt+xj3VqFpwz9/flPmLJGq4Wuw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/circuit-relay-v2/-/circuit-relay-v2-4.2.4.tgz",
+      "integrity": "sha512-e955bA2XiDzhs+y23pgIOayOEqaPuLGfPxnXAlJ+4ECLxtEOxPaUKBq5XowkwZwqn0wwBbgGZ8LBcJikr4Q68g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.17",
+        "@libp2p/crypto": "^5.1.18",
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/interface-internal": "^3.1.3",
-        "@libp2p/peer-collections": "^7.0.18",
-        "@libp2p/peer-id": "^6.0.8",
-        "@libp2p/peer-record": "^9.0.9",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/interface-internal": "^3.1.4",
+        "@libp2p/peer-collections": "^7.0.19",
+        "@libp2p/peer-id": "^6.0.9",
+        "@libp2p/peer-record": "^9.0.10",
+        "@libp2p/utils": "^7.2.0",
         "@multiformats/multiaddr": "^13.0.1",
         "@multiformats/multiaddr-matcher": "^3.0.1",
         "any-signal": "^4.1.1",
@@ -2049,23 +2055,34 @@
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/config": {
-      "version": "1.1.30",
-      "resolved": "https://registry.npmjs.org/@libp2p/config/-/config-1.1.30.tgz",
-      "integrity": "sha512-uidU1FCYaDIIWfk6u4VAv4iG4ZihQnv4SiI8WQ5NLzWJzIojD5t6j3JlEgTKKcs3Xoz/odj+z67BJFKFVrHkdA==",
+    "node_modules/@libp2p/circuit-relay-v2/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.17",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/config": {
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/@libp2p/config/-/config-1.1.31.tgz",
+      "integrity": "sha512-4G1rGzNuTmNtqUxD/9kpC4/C+aPLSMy+q6exhm9E+cORb+AjW1Q90Oef2uKVj2eWWw14Rw7r2mK3jEa5IWVL8g==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.18",
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/keychain": "^6.1.0",
-        "@libp2p/logger": "^6.2.6",
+        "@libp2p/keychain": "^6.1.1",
+        "@libp2p/logger": "^6.2.7",
         "interface-datastore": "^9.0.1"
       }
     },
     "node_modules/@libp2p/crypto": {
-      "version": "5.1.17",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.17.tgz",
-      "integrity": "sha512-gzn9b3tX9D5xCiXb36PF0rH16kGkLW5ESbT+nmXKUp1HCDD30RXQT/oHSylz5I3GN39BC1C3hBOBNaIQYuO+qw==",
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.18.tgz",
+      "integrity": "sha512-sCm+dFFZmH4LJIHTCzPy7+EBRhzkndFUcIU8bui6iaxK6SDSRVa11+/O6DzW8hn/U9LgDXe6jXnzWM8bM7OoCA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.2",
@@ -2077,20 +2094,42 @@
         "uint8arrays": "^5.1.0"
       }
     },
+    "node_modules/@libp2p/crypto/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
     "node_modules/@libp2p/dcutr": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/@libp2p/dcutr/-/dcutr-3.0.18.tgz",
-      "integrity": "sha512-hNYCeVemXgG1SWG/xr/D9dmzPLzBiS/ubVEWbUBAciopTkTu+lebCw+KPY2nKtGoDt2qWYq9XBCw1RtcQt7Kfg==",
+      "version": "3.0.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/dcutr/-/dcutr-3.0.19.tgz",
+      "integrity": "sha512-plhWCWn4IzLUnrpc/i+Lulz0YQAR41i9P3/o6B6dnqzXENgJXM8kplbfQfmTmZepNSuGNgxdZ2Ra8PZbXx4Rtg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/interface-internal": "^3.1.3",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/interface-internal": "^3.1.4",
+        "@libp2p/utils": "^7.2.0",
         "@multiformats/multiaddr": "^13.0.1",
         "@multiformats/multiaddr-matcher": "^3.0.1",
         "delay": "^7.0.0",
         "protons-runtime": "^6.0.1",
         "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/dcutr/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/http": {
@@ -2175,23 +2214,34 @@
       }
     },
     "node_modules/@libp2p/identify": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/identify/-/identify-4.1.3.tgz",
-      "integrity": "sha512-EhUr3o611Ax9xKJPLvCgHBpEO3lWW+ss2NjLpL9GXQRbyp7pcN2C5ZgHzDfMfHdXPoIqKrrALaVc0z2c+cn0zA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/identify/-/identify-4.1.4.tgz",
+      "integrity": "sha512-EqbFg56MA9XWZf5IHV1Nd4RFq459qzIfIPLgk0x55muOoYZcvRhGY8NmNjxww/AUqCXVbzh6jMHyjoIOs7cvLw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.17",
+        "@libp2p/crypto": "^5.1.18",
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/interface-internal": "^3.1.3",
-        "@libp2p/peer-id": "^6.0.8",
-        "@libp2p/peer-record": "^9.0.9",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/interface-internal": "^3.1.4",
+        "@libp2p/peer-id": "^6.0.9",
+        "@libp2p/peer-record": "^9.0.10",
+        "@libp2p/utils": "^7.2.0",
         "@multiformats/multiaddr": "^13.0.1",
         "@multiformats/multiaddr-matcher": "^3.0.1",
         "it-drain": "^3.0.10",
         "it-parallel": "^3.0.13",
         "main-event": "^1.0.1",
         "protons-runtime": "^6.0.1",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/identify/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
@@ -2211,31 +2261,31 @@
       }
     },
     "node_modules/@libp2p/interface-internal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.3.tgz",
-      "integrity": "sha512-rDmIL7YUplnaD33/5K40Aue7dHIg4FvIm+swE4tXey2p2wpcn1KE7fzbAX0dFJkHufuI8H/W3zn/iw3ZQgbFjg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.4.tgz",
+      "integrity": "sha512-8pHJ3SeGyLTUw9F5r5aNQtHI+UtrHMNkk7ou3xFs6HOevDtzzzwexXw4CBCeewLHMI8s/rbxvX57laXr1EAoYQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/peer-collections": "^7.0.18",
+        "@libp2p/peer-collections": "^7.0.19",
         "@multiformats/multiaddr": "^13.0.1",
         "progress-events": "^1.0.1"
       }
     },
     "node_modules/@libp2p/kad-dht": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/kad-dht/-/kad-dht-16.2.4.tgz",
-      "integrity": "sha512-H0YTgs4f+z5xLSgR3esLvSsSYKJ8Ngik7y77Bw1zOba2sdWwQ/QKKgxGiVqcRwlIXPwNiJ/MQd2o62Mdo/Mqlg==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/kad-dht/-/kad-dht-16.2.5.tgz",
+      "integrity": "sha512-CAO0lv7rzp34F+zpcQoqzJDdepiCbPQKKctFDUzlxNJDI2WUNNs0kQ5PSvGqqf5ifQpHHmcj+xukX5pToEzlOw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.17",
+        "@libp2p/crypto": "^5.1.18",
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/interface-internal": "^3.1.3",
-        "@libp2p/peer-collections": "^7.0.18",
-        "@libp2p/peer-id": "^6.0.8",
-        "@libp2p/ping": "^3.1.3",
+        "@libp2p/interface-internal": "^3.1.4",
+        "@libp2p/peer-collections": "^7.0.19",
+        "@libp2p/peer-id": "^6.0.9",
+        "@libp2p/ping": "^3.1.4",
         "@libp2p/record": "^4.0.12",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/utils": "^7.2.0",
         "@multiformats/multiaddr": "^13.0.1",
         "@multiformats/multiaddr-matcher": "^3.0.1",
         "any-signal": "^4.1.1",
@@ -2261,13 +2311,24 @@
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/keychain": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-6.1.0.tgz",
-      "integrity": "sha512-X/AdUB53uV00VRIRf2mX8fByvSx6bpfQbEdx8nHtLTVgcfnSDfFYIw8krd8ZnzgBNCbN+osMJn151Ft+QHkeBQ==",
+    "node_modules/@libp2p/kad-dht/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.17",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/keychain": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-6.1.1.tgz",
+      "integrity": "sha512-szZBnnO+VX4Fjz6KZKE6Z0mFEWaQautb5sV+cK23r6nZ17gd3dv/U8hI2I2DjtPDKB3HimpQcVLnDF8Tc3EkfQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.18",
         "@libp2p/interface": "^3.2.2",
         "@noble/hashes": "^2.0.1",
         "asn1js": "^3.0.6",
@@ -2278,9 +2339,9 @@
       }
     },
     "node_modules/@libp2p/logger": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.6.tgz",
-      "integrity": "sha512-ep2fNBFZHVomQEvXk0NET2Y85csVeQbFpCvT94uQrtP4MrRE6zVjxiuh67KZuE32odnoKwE29i2fWPHc1p1Xng==",
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.7.tgz",
+      "integrity": "sha512-IVEz5+0kE4mRWwMzXP34AlXe2k1FLzBqKkjeASyhPVdMz0A4qH9nYmCBwonzmRzymklGjFIEDa1s7Vjhd9V4Rg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.2",
@@ -2291,15 +2352,15 @@
       }
     },
     "node_modules/@libp2p/mdns": {
-      "version": "12.0.19",
-      "resolved": "https://registry.npmjs.org/@libp2p/mdns/-/mdns-12.0.19.tgz",
-      "integrity": "sha512-xcMKIfnb2oxoJ8e5DH8AgH/EorL+8D6jFs5EbzH60q4hbAROUlkLjgx5l87PNhs3Rao+j8B0W+YJ1CqseeEcrQ==",
+      "version": "12.0.21",
+      "resolved": "https://registry.npmjs.org/@libp2p/mdns/-/mdns-12.0.21.tgz",
+      "integrity": "sha512-FbHfUNogRAwTGMNM2QDryuW0mSx1J00JXQynZh4LpTXDLoj5Q34irysXxHryOqGru24Y86n438NzKqZrCscAnw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/interface-internal": "^3.1.3",
-        "@libp2p/peer-id": "^6.0.8",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/interface-internal": "^3.1.4",
+        "@libp2p/peer-id": "^6.0.9",
+        "@libp2p/utils": "^7.2.0",
         "@multiformats/multiaddr": "^13.0.1",
         "@types/multicast-dns": "^7.2.4",
         "dns-packet": "^5.6.1",
@@ -2308,13 +2369,13 @@
       }
     },
     "node_modules/@libp2p/mplex": {
-      "version": "12.0.19",
-      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-12.0.19.tgz",
-      "integrity": "sha512-jQYdwgX9Abxm/8Qxf8yVXP1hxnPiSRpCrWIuHGx1tP4ulV3kzMeIprnguN8c8tqk5Kl0ATZK6viVA9XKD7JbQw==",
+      "version": "12.0.21",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-12.0.21.tgz",
+      "integrity": "sha512-0w8FQCT3DwB886knb4pDJ4fNclr+hBBJ8GJXqKQYp33EJWtoO7NKLW8Khxp7WmypEqOoO34hDMj6JgISSfBbuw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/utils": "^7.2.0",
         "it-pushable": "^3.2.3",
         "uint8-varint": "^2.0.4",
         "uint8arraylist": "^2.4.8",
@@ -2322,51 +2383,51 @@
       }
     },
     "node_modules/@libp2p/multistream-select": {
-      "version": "7.0.18",
-      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-7.0.18.tgz",
-      "integrity": "sha512-Twctbqr2rnPnTf2iPIwKq4LzpI29gKwogtmqr0qJh2+IMKH+MtwhT+s+c0Mb2A+n+Td0AceRRddWS5DOaFskVg==",
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-7.0.19.tgz",
+      "integrity": "sha512-si1Abjnyi3o3s7Z2H7CPvsfUi+KLID7m0Qce6bzuZ330C/zQaj0WorcFsUxjhT8g4sFljOWs3Gj85qcCkxoQtA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/utils": "^7.2.0",
         "it-length-prefixed": "^10.0.1",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/peer-collections": {
-      "version": "7.0.18",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-7.0.18.tgz",
-      "integrity": "sha512-xcUmToljkDFEKwQrbgrGGaVbX6Z8/ir4MTBlGpyo8H8JRxnfQ0ybvVbHiEeX5OpFMT3e/bQrcdfydFDJKy3hWA==",
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-7.0.19.tgz",
+      "integrity": "sha512-vUV6kovHqYQQP2oLq7Ph12AfDRDgsSgE+WfF1slRm1xY4AFmDP6EnCEQwPzmxHVbkfP4XiekgLZ48NDRh4/f2Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/peer-id": "^6.0.8",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/peer-id": "^6.0.9",
+        "@libp2p/utils": "^7.2.0",
         "multiformats": "^13.4.0"
       }
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.8.tgz",
-      "integrity": "sha512-D9fkXL5g+RfSvDVnj/DxVeuGPq5SQrWPWf4VPf+pPkIZVcTOuuR6OUN9XtYfOUxeN3CbsoAlRk0EDXqRA8Zyxg==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.9.tgz",
+      "integrity": "sha512-MlofyOOpxzZA4tIcOVPjd1FQIa0TA0g+bn+d08vfo9znCjfe6Lh0RBFyLdlICbyogVN6wn7+29SYch78wCuuCQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.17",
+        "@libp2p/crypto": "^5.1.18",
         "@libp2p/interface": "^3.2.2",
         "multiformats": "^13.4.0",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/peer-record": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-9.0.9.tgz",
-      "integrity": "sha512-MSTa01yTEvlaxW2Z/jiLYviPFWB7UJjupxHOSFTqalvJQYFuR4C713o6ABFEQWJJ2mTB0dS79hs65lEbOuWQTw==",
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-9.0.10.tgz",
+      "integrity": "sha512-pbDHpOPzE2vLlyiIAitpKG+aDNcnVmtLCYb1wGeRRAnarZC/vREZGM6JmR8Y79INu7jQ1IwTN1iKMj9jaXdAGg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.17",
+        "@libp2p/crypto": "^5.1.18",
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/peer-id": "^6.0.8",
+        "@libp2p/peer-id": "^6.0.9",
         "@multiformats/multiaddr": "^13.0.1",
         "multiformats": "^13.4.0",
         "protons-runtime": "^6.0.1",
@@ -2375,17 +2436,28 @@
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/peer-store": {
-      "version": "12.0.18",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-12.0.18.tgz",
-      "integrity": "sha512-RLTW+5vQJY/em+xFqaZe6vN7M2dEVYjr+4XCevU5XWGGWfsZy+HC7DkoH+o3wqptnniCewqtpF1Vf8LhaivGXw==",
+    "node_modules/@libp2p/peer-record/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.17",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store": {
+      "version": "12.0.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-12.0.19.tgz",
+      "integrity": "sha512-M2IvJ+pmQQT680d3uHm4SYz0CAwWtqyTVl1iMRQw/N13GAp3kot+sSwLaYnMBEKFHzLEi7e9HPWC2tYDFspxvg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.18",
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/peer-collections": "^7.0.18",
-        "@libp2p/peer-id": "^6.0.8",
-        "@libp2p/peer-record": "^9.0.9",
+        "@libp2p/peer-collections": "^7.0.19",
+        "@libp2p/peer-id": "^6.0.9",
+        "@libp2p/peer-record": "^9.0.10",
         "@multiformats/multiaddr": "^13.0.1",
         "interface-datastore": "^9.0.1",
         "it-all": "^3.0.9",
@@ -2397,15 +2469,26 @@
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/ping": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/ping/-/ping-3.1.3.tgz",
-      "integrity": "sha512-ZdlMWE4N0cHcDfOnp3Zi1STCBYRR9BPNNn5Wg03AZj7FbCKmlin03Uf1EKl5TcdlVm+E8z8uCB3+wIGtFHQByA==",
+    "node_modules/@libp2p/peer-store/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.17",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/ping": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/ping/-/ping-3.1.4.tgz",
+      "integrity": "sha512-jKv4sdV5AkcR3jqUqEnH5AMUKbBEaPh57g9Vn5Fz+nFV8zwNQYN0VFpIyYLGRi3myvkLQ3R/0segiltQKxiSkA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.18",
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/interface-internal": "^3.1.3",
+        "@libp2p/interface-internal": "^3.1.4",
         "p-event": "^7.0.0",
         "race-signal": "^2.0.0",
         "uint8arraylist": "^2.4.8",
@@ -2423,14 +2506,25 @@
         "uint8arrays": "^5.1.0"
       }
     },
+    "node_modules/@libp2p/record/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
     "node_modules/@libp2p/tcp": {
-      "version": "11.0.18",
-      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-11.0.18.tgz",
-      "integrity": "sha512-Ha7C4P24eAp4a9eLSqfutGnN1Y+BBa1VbscJVXPqX2mm6lOulk1ieRThYF60jZdHTNI6C97GuhLTg58FzxdJGA==",
+      "version": "11.0.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-11.0.19.tgz",
+      "integrity": "sha512-K5rGoFS+PfdSon3gkyCwx9WTqwUFmJlCmnUi1624L2275/f/LN5TQ5XELRgXw6H23ZWNdfNLmOg/qw1I4U4s9w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/utils": "^7.2.0",
         "@multiformats/multiaddr": "^13.0.1",
         "@multiformats/multiaddr-matcher": "^3.0.1",
         "main-event": "^1.0.1",
@@ -2440,15 +2534,15 @@
       }
     },
     "node_modules/@libp2p/tls": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/tls/-/tls-3.1.0.tgz",
-      "integrity": "sha512-plW0TRrOxvX4a36ZHmRcM7g3Gdgk84C8O51ZL3ngH/RxeYbaS7cc46vzX996l+uUwAfsRHW996nLC/gptl6Awg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/tls/-/tls-3.1.1.tgz",
+      "integrity": "sha512-lDz7tmGtkvzMZw7IAUBSFgjL8zxAIGxHrBotjicWxcNeVALUp28doCJqb93ad7EyQRuHFZCD3bXgUl/P6Dj5yQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.17",
+        "@libp2p/crypto": "^5.1.18",
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/peer-id": "^6.0.8",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/peer-id": "^6.0.9",
+        "@libp2p/utils": "^7.2.0",
         "@peculiar/asn1-schema": "^2.4.0",
         "@peculiar/asn1-x509": "^2.4.0",
         "@peculiar/webcrypto": "^1.5.0",
@@ -2482,17 +2576,28 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@libp2p/tls/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
     "node_modules/@libp2p/upnp-nat": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@libp2p/upnp-nat/-/upnp-nat-4.0.18.tgz",
-      "integrity": "sha512-kDSj1nLE+wfvhRx/N8rFEy277Qjc+iKLn4NJLqCkmzjwxkQXzVgkRMNB900t4qIxGfVsVnV35UxbL49Yi8UsRQ==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/upnp-nat/-/upnp-nat-4.0.19.tgz",
+      "integrity": "sha512-INUMoD3UGBoSYkL7G8pv7ihmaCMWpOIfvV74itiW6Kfilzq/TDveTikN5KYv235d0FHZ8Zs/FmC0TBEhWB6nYA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@achingbrain/nat-port-mapper": "^4.0.4",
         "@chainsafe/is-ip": "^2.1.0",
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/interface-internal": "^3.1.3",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/interface-internal": "^3.1.4",
+        "@libp2p/utils": "^7.2.0",
         "@multiformats/multiaddr": "^13.0.1",
         "@multiformats/multiaddr-matcher": "^3.0.1",
         "main-event": "^1.0.1",
@@ -2501,17 +2606,18 @@
       }
     },
     "node_modules/@libp2p/utils": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-7.1.0.tgz",
-      "integrity": "sha512-gfOpPIMpv+B4XXIsmXVN41p6kFrBw8yC2OwNaX6sjTwf7s1GmpQ/O0R4nI0P2t0RzBELy1EG8DgUmlxZOvdwjA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-7.2.0.tgz",
+      "integrity": "sha512-XvzCyjK7Tc5sYG/wOlo0l2BVk7KgQu2Q1+SC+WRFAQz+sPTiAzwe5buxAYQaBUb/upIrnD0alyWbcdUCkz5LFA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.1.0",
         "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/crypto": "^5.1.17",
+        "@libp2p/crypto": "^5.1.18",
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/logger": "^6.2.6",
+        "@libp2p/logger": "^6.2.7",
         "@multiformats/multiaddr": "^13.0.1",
+        "@multiformats/multiaddr-matcher": "^3.0.1",
         "@sindresorhus/fnv1a": "^3.1.0",
         "any-signal": "^4.1.1",
         "cborg": "^5.1.0",
@@ -2533,19 +2639,19 @@
       }
     },
     "node_modules/@libp2p/webrtc": {
-      "version": "6.0.20",
-      "resolved": "https://registry.npmjs.org/@libp2p/webrtc/-/webrtc-6.0.20.tgz",
-      "integrity": "sha512-hdSgAgXaL0+dbOTNbf5+OQdZHGNQQGVHlursquM3HHsKtkIOVWEWre2Wo8UhAT/LcLtZDVkcx+xsBQmF6ASPyQ==",
+      "version": "6.0.22",
+      "resolved": "https://registry.npmjs.org/@libp2p/webrtc/-/webrtc-6.0.22.tgz",
+      "integrity": "sha512-3xtMLynwzp8Ig2y0vcNw8KRts12XZT4jZWv07OQpXuTKuQ0WiFG+DS70+q0bKWgF9zX5bu3DmcGY3FqRlIkQsQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.1.0",
         "@chainsafe/libp2p-noise": "^17.0.0",
-        "@libp2p/crypto": "^5.1.17",
+        "@libp2p/crypto": "^5.1.18",
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/interface-internal": "^3.1.3",
-        "@libp2p/keychain": "^6.1.0",
-        "@libp2p/peer-id": "^6.0.8",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/interface-internal": "^3.1.4",
+        "@libp2p/keychain": "^6.1.1",
+        "@libp2p/peer-id": "^6.0.9",
+        "@libp2p/utils": "^7.2.0",
         "@multiformats/multiaddr": "^13.0.1",
         "@multiformats/multiaddr-matcher": "^3.0.1",
         "@peculiar/webcrypto": "^1.5.0",
@@ -2558,7 +2664,7 @@
         "it-stream-types": "^2.0.2",
         "main-event": "^1.0.1",
         "multiformats": "^13.4.0",
-        "node-datachannel": "^0.29.0",
+        "node-datachannel": "^0.32.3",
         "p-defer": "^4.0.1",
         "p-event": "^7.0.0",
         "p-timeout": "^7.0.0",
@@ -2594,14 +2700,25 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@libp2p/webrtc/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
     "node_modules/@libp2p/websockets": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-10.1.11.tgz",
-      "integrity": "sha512-Ii69/m4mHPimJyPqEG7NCO4NHImgs9eKhOlELmvYWYZlYbpffWoNUu7XiN/y5x3w5UwPirzmNmX4ORZrzzk6Sg==",
+      "version": "10.1.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-10.1.12.tgz",
+      "integrity": "sha512-QDLAZNYbbfvQRQSyrfvL7Kg4zJb3Shu5vdf2xYtWVLXeE7QSDL1GO8XMexq8D1bZZ6DpUgdMnuRgDqe0zxH6cw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/utils": "^7.2.0",
         "@multiformats/multiaddr": "^13.0.1",
         "@multiformats/multiaddr-matcher": "^3.0.1",
         "@multiformats/multiaddr-to-uri": "^12.0.0",
@@ -2676,17 +2793,23 @@
       }
     },
     "node_modules/@multiformats/murmur3": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.2.2.tgz",
-      "integrity": "sha512-B37HsL4uqZpKzOPRNmpr9hR1lbywZfJR053sYgkQGnnbfNzM1Nw4SlL9I8hMAZRk1TOqr8q+PeaFeuNmKgi2YA==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.2.5.tgz",
+      "integrity": "sha512-M+VwV8hEx5qB8i7b8fljMwZETJsqyLo8RAXA+JAn+QF9NnH46ZWvGErNukJVlxXSR2KQpuOtHIYIzZlbhhdFvw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "multiformats": "^13.0.0"
+        "multiformats": "^14.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
+    },
+    "node_modules/@multiformats/murmur3/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@multiformats/uri-to-multiaddr": {
       "version": "10.0.0",
@@ -2980,23 +3103,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.62.0.tgz",
-      "integrity": "sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.214.0",
-        "@opentelemetry/redis-common": "^0.38.2",
-        "@opentelemetry/semantic-conventions": "^1.33.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-kafkajs": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.23.0.tgz",
@@ -3148,23 +3254,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.62.0.tgz",
-      "integrity": "sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.214.0",
-        "@opentelemetry/redis-common": "^0.38.2",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-tedious": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.33.0.tgz",
@@ -3180,15 +3269,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/redis-common": {
-      "version": "0.38.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.3.tgz",
-      "integrity": "sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
@@ -3251,127 +3331,127 @@
       }
     },
     "node_modules/@peculiar/asn1-cms": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
-      "integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
-        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-csr": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
-      "integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-ecc": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
-      "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pfx": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
-      "integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.6.1",
-        "@peculiar/asn1-pkcs8": "^2.6.1",
-        "@peculiar/asn1-rsa": "^2.6.1",
-        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pkcs8": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
-      "integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pkcs9": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
-      "integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.6.1",
-        "@peculiar/asn1-pfx": "^2.6.1",
-        "@peculiar/asn1-pkcs8": "^2.6.1",
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
-        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-rsa": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
-      "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
       "license": "MIT",
       "dependencies": {
+        "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.6",
-        "pvtsutils": "^1.3.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
-      "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.6",
-        "pvtsutils": "^1.3.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509-attr": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
-      "integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
@@ -3388,20 +3468,29 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
-      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+      "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
         "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2",
-        "webcrypto-core": "^1.8.0"
+        "@peculiar/utils": "^2.0.2",
+        "tslib": "^2.8.1",
+        "webcrypto-core": "^1.9.2"
       },
       "engines": {
-        "node": ">=10.12.0"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/@peculiar/x509": {
@@ -3977,18 +4066,18 @@
       }
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.85.2.tgz",
-      "integrity": "sha512-kauC/oPaxklU4Y+u9gBfCBJm51qX6WBZq4xx0USCdimtp+G8+554kpygfSWIjoqCJa2o06bWxBEjesiuCv+LzA==",
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.85.3.tgz",
+      "integrity": "sha512-u9ZiYP23vA2IFtdFQFmetzSmk6SM0xgKIoiOsr1hXNHjHaLhOm+/Ph1ud57wX6+Dbwdzx8coJgnzSKL3W21PCg==",
       "license": "MIT",
       "engines": {
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.85.2.tgz",
-      "integrity": "sha512-XCginmxh0//++EXVOEJHBVZxHla294FzLCFF6jXwAUjvXVhqyIKyxhABfz+r4OOmaiuWk4Rtd4arqdAzeHeprg==",
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.85.3.tgz",
+      "integrity": "sha512-/JkS1lGLyzBWP1FbgDwaqEf7qShIC6pUC1M0a/YMAd/v4iqR24MRkQWe7jkYvcBQ2LpEhs5NGE9InhxSv21zCA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -4007,17 +4096,17 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.85.2.tgz",
-      "integrity": "sha512-3KLgSg1kHvBpr93zMaQhvfYTgnCw7yZRED+3J4dMcYjfSjtD0Wf8SofU6uBmAw9JaVYvP43lpdwUpI4p0+ABsg==",
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.85.3.tgz",
+      "integrity": "sha512-fs85dmbIqNmtzEixDb0g+q6R3Vt4H9eAt8/inIZdDKfjN76+sUJA2r1nxODQ76bU23MrIbz8sI7KFBPaWk/zQw==",
       "license": "MIT",
       "dependencies": {
-        "@react-native/dev-middleware": "0.85.2",
+        "@react-native/dev-middleware": "0.85.3",
         "debug": "^4.4.0",
         "invariant": "^2.2.4",
-        "metro": "^0.84.0",
-        "metro-config": "^0.84.0",
-        "metro-core": "^0.84.0",
+        "metro": "^0.84.3",
+        "metro-config": "^0.84.3",
+        "metro-core": "^0.84.3",
         "semver": "^7.1.3"
       },
       "engines": {
@@ -4025,7 +4114,7 @@
       },
       "peerDependencies": {
         "@react-native-community/cli": "*",
-        "@react-native/metro-config": "0.85.2"
+        "@react-native/metro-config": "0.85.3"
       },
       "peerDependenciesMeta": {
         "@react-native-community/cli": {
@@ -4037,9 +4126,9 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4049,18 +4138,18 @@
       }
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.85.2.tgz",
-      "integrity": "sha512-j+0b9H5f5hGTLQxHIhJU/b/W6ijuxJF+ZTLHB0se2kzUBNxFKd7DkIc6753qk3CJdiv55vxG3XDgmlpbHxOpmA==",
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.85.3.tgz",
+      "integrity": "sha512-uAu7rM5o/Np1zgp6fi5zM1sP1aB8DcS7DdOLcj/TkSutOAjkMqqd2lWt1/+3S7qXexRHVK5XcP+o3VXo4L/V0A==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
     "node_modules/@react-native/debugger-shell": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.85.2.tgz",
-      "integrity": "sha512-r5BkhqPMfg3LmaZS5zadHmBNVH5h4bhSpv4BEPGfK4gat9HABAMzUzybi+2wpgU3SoHxnyKGdExEJvoqVcjeRg==",
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.85.3.tgz",
+      "integrity": "sha512-/jRAaT9boiCttIcEwS02WPwYkUihqsjSaK/TMtHz05vT6uMgac9PaQt5kzBQLIABv5aEIa5gtrMmKVz49MjkjQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -4072,14 +4161,14 @@
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.85.2.tgz",
-      "integrity": "sha512-3J+NaDUg+QEfDeLAUzgaWhpaxEg78g+KwbydlDCewh2G6WnHpsty8XooruxNHzyAsqVWywZMrzmbn78Ctc1O9Q==",
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.85.3.tgz",
+      "integrity": "sha512-JYzBiT4A8w+KQt+dOD5v+ti+tDrGoPnsSTuApq3Ls4RB5sfWbDlYMyz3dbc8qBIHz9tv0sQ5+eOu6Xwqzr5AQA==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.85.2",
-        "@react-native/debugger-shell": "0.85.2",
+        "@react-native/debugger-frontend": "0.85.3",
+        "@react-native/debugger-shell": "0.85.3",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.3.0",
         "connect": "^3.6.5",
@@ -4116,33 +4205,33 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.85.2.tgz",
-      "integrity": "sha512-YXBOLeAqFrv7XwUeBPTKZeOV1FIxn4AW7UAEitScf3ibC8bu8+6NpJu4HWgbNQHg7vDbbTZVbcOl8EwGxsSq2w==",
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.85.3.tgz",
+      "integrity": "sha512-39dY2j50Q1pntejzwt3XL7vwXtrj8jcIfHq6E+gyu3jzYxZJVvMkMutQ39vSg6zinIQOX36oQDhidXUbCXzgoA==",
       "license": "MIT",
       "engines": {
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.85.2.tgz",
-      "integrity": "sha512-esGEAmKVM40DV/yVmNljCKZTIeUo7qXqc+Hwffkv3TG+b3E24xyFovHrbP98gGxZr2ZsEyx+2sKLdXF5asY5nw==",
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.85.3.tgz",
+      "integrity": "sha512-U2+aMshIXf1uFn77tpBb/xhHWB9vkVrMpt7kkucAugF8hJKYTDGB587X7WwelHduK2KBfhl4giSv0rzZGoef9A==",
       "license": "MIT",
       "engines": {
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.85.2.tgz",
-      "integrity": "sha512-svuOLtjbFGXDdHsriHXuND5FgHg7XlkOXCbH/8+X4t76YLH6qSTffSIQQrKLDL5mn4EFU+Oh/PNO0/FfpnTOTg==",
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.85.3.tgz",
+      "integrity": "sha512-hj0PScZEhIbcOvQV5yMKX3ha4XEIOy/SVE1Rrpp0beW0dpNLOgSC7KDxGewmDnIHK9YdQUXGY9eMEfShUMIaZw==",
       "license": "MIT"
     },
     "node_modules/@react-native/virtualized-lists": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.85.2.tgz",
-      "integrity": "sha512-wmVKpAlcr+UB0L5SpbrV865EdleUP7I5+X+48e1aRsQK8q+wsTRBXeUwWVip/1l+HZwlZFeO8iOILJ16VRu0Cw==",
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.85.3.tgz",
+      "integrity": "sha512-dsCjI//OIPEUJMyNHp4l7zNLVjCx7bcaRUceOCkU+IB17hkbtbGWvi7HjGFSzy7FJGmS/MOlcfpb72xXiy1Oig==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4",
@@ -4154,7 +4243,7 @@
       "peerDependencies": {
         "@types/react": "^19.2.0",
         "react": "*",
-        "react-native": "0.85.2"
+        "react-native": "0.85.3"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4193,9 +4282,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
       "cpu": [
         "arm"
       ],
@@ -4206,9 +4295,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
       "cpu": [
         "arm64"
       ],
@@ -4219,9 +4308,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
       "cpu": [
         "arm64"
       ],
@@ -4232,9 +4321,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
       "cpu": [
         "x64"
       ],
@@ -4245,9 +4334,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
       "cpu": [
         "arm64"
       ],
@@ -4258,9 +4347,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
       "cpu": [
         "x64"
       ],
@@ -4271,9 +4360,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
       "cpu": [
         "arm"
       ],
@@ -4284,9 +4373,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
       ],
@@ -4297,9 +4386,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
       "cpu": [
         "arm64"
       ],
@@ -4310,9 +4399,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
       ],
@@ -4323,9 +4412,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
       "cpu": [
         "loong64"
       ],
@@ -4336,9 +4425,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
       "cpu": [
         "loong64"
       ],
@@ -4349,9 +4438,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
       "cpu": [
         "ppc64"
       ],
@@ -4362,9 +4451,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
       "cpu": [
         "ppc64"
       ],
@@ -4375,9 +4464,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
       "cpu": [
         "riscv64"
       ],
@@ -4388,9 +4477,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
       ],
@@ -4401,9 +4490,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
       "cpu": [
         "s390x"
       ],
@@ -4414,9 +4503,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
       "cpu": [
         "x64"
       ],
@@ -4427,9 +4516,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
       ],
@@ -4440,9 +4529,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
       "cpu": [
         "x64"
       ],
@@ -4453,9 +4542,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
       "cpu": [
         "arm64"
       ],
@@ -4466,9 +4555,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
       "cpu": [
         "arm64"
       ],
@@ -4479,9 +4568,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
       "cpu": [
         "ia32"
       ],
@@ -4492,9 +4581,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
       "cpu": [
         "x64"
       ],
@@ -4505,9 +4594,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
       "cpu": [
         "x64"
       ],
@@ -4593,84 +4682,84 @@
       }
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.50.0.tgz",
-      "integrity": "sha512-42bxyRTxnCmYlWnvz4CxikuQNanw8UNma2WJrtxJ0f1MAJV2GhQGSHDLnA+lvFlmiz6qct3pfen/NXGyOTegTA==",
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.52.0.tgz",
+      "integrity": "sha512-x/yEPZdpH6NGQeoeQnV9tj8reAH8twNttiltGZl2o8Rk7sQeUfe7E8yuYP2XbJ2RqyZK5qRS3COrNyMPzf6KFA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.50.0"
+        "@sentry/core": "10.52.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.50.0.tgz",
-      "integrity": "sha512-0k9XZF0wn86f77mIO2U3gNNyDZooy139CnEanRzHinrN106vVzvBZ6TUEQoHtoO1fqQxr+nWWVrqV/PXUqk47w==",
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.52.0.tgz",
+      "integrity": "sha512-5kAn1W8ZvCuHtEHXpq6iRkUMdNCilwww+YxaN2yofVrCivAbB3Ha5JJUMqmWOPW0pC27zGYmoJMIDvG+PczUxA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.50.0"
+        "@sentry/core": "10.52.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.50.0.tgz",
-      "integrity": "sha512-51FYNfnvVLAWw1rrEWPFfwHuMRb9mkVCFGA4J9/un7SpeGBsQDziGB0Di4fsCxI7+EdSBpfLHPF0csKtCCw0oQ==",
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.52.0.tgz",
+      "integrity": "sha512-diywyuc/H7VTUR+W5ryVmLF+0X4UP1OskMqb6V8RSAvJHcj2JmIm7uP+Fc6ACTno+b6AUShwT/L4xVXzO6X9Cw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.50.0",
-        "@sentry/core": "10.50.0"
+        "@sentry-internal/browser-utils": "10.52.0",
+        "@sentry/core": "10.52.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.50.0.tgz",
-      "integrity": "sha512-jx6RKBmcJSWdI92qDGS/sBv1w+7Cww879Z/moX7bw7ipHa/Ts3iDcB3rgZwvhmi17U+mvYsbJeL2DXkPo3TjPw==",
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.52.0.tgz",
+      "integrity": "sha512-BI5ie4dxPuUJ344CXVSnAxY1xZCbghglPSCIlTOYODpR9so9yo5IZh+Mwspt0oWsUMaxWJiQSNYlbPWi7WDavg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "10.50.0",
-        "@sentry/core": "10.50.0"
+        "@sentry-internal/replay": "10.52.0",
+        "@sentry/core": "10.52.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.50.0.tgz",
-      "integrity": "sha512-1f6rAvET6myiTaSeYqvaaBwvq1LfxqWjAPIoAW/NVC9bPMkeEcuvgDajHrnZMrBeWoJ81NMyoLkyX+iOc7MoFA==",
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.52.0.tgz",
+      "integrity": "sha512-ijL9jN86oXwXQWbwhPlEb70ODJSEmjxQEQdnZkC4gDWbjswcwvRsVJPYk+1xl2ir2iZixRIHipVxDcLwian35g==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.50.0",
-        "@sentry-internal/feedback": "10.50.0",
-        "@sentry-internal/replay": "10.50.0",
-        "@sentry-internal/replay-canvas": "10.50.0",
-        "@sentry/core": "10.50.0"
+        "@sentry-internal/browser-utils": "10.52.0",
+        "@sentry-internal/feedback": "10.52.0",
+        "@sentry-internal/replay": "10.52.0",
+        "@sentry-internal/replay-canvas": "10.52.0",
+        "@sentry/core": "10.52.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.50.0.tgz",
-      "integrity": "sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg==",
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.52.0.tgz",
+      "integrity": "sha512-VA/kAqLhkMnRWY2RXdBLyTemR9D4m7MVRy/gyapoq9yvllVPx9WXbvKgnMP2LQp7mFgT/oLFvw58aQKaYTGn3A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.51.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.51.0.tgz",
-      "integrity": "sha512-2yZLRZwS1dKG8/4eOTpGSo/gO/EgmT9aPj6lAzUkRa7bZCTTdW4BraaHU0leX5T94909Qfhbr3W5AVTfDOCKiQ==",
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.52.0.tgz",
+      "integrity": "sha512-9+p3KJUk3rHO1HOEZuSknP2RgKCJZONDm4HWgkVDtVBtocb66KLtVlMjc59d2/bWP7tM3wc877tpG30quFfU9g==",
       "license": "MIT",
       "dependencies": {
         "@fastify/otel": "0.18.0",
@@ -4685,7 +4774,6 @@
         "@opentelemetry/instrumentation-graphql": "0.62.0",
         "@opentelemetry/instrumentation-hapi": "0.60.0",
         "@opentelemetry/instrumentation-http": "0.214.0",
-        "@opentelemetry/instrumentation-ioredis": "0.62.0",
         "@opentelemetry/instrumentation-kafkajs": "0.23.0",
         "@opentelemetry/instrumentation-knex": "0.58.0",
         "@opentelemetry/instrumentation-koa": "0.62.0",
@@ -4695,14 +4783,13 @@
         "@opentelemetry/instrumentation-mysql": "0.60.0",
         "@opentelemetry/instrumentation-mysql2": "0.60.0",
         "@opentelemetry/instrumentation-pg": "0.66.0",
-        "@opentelemetry/instrumentation-redis": "0.62.0",
         "@opentelemetry/instrumentation-tedious": "0.33.0",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
         "@prisma/instrumentation": "7.6.0",
-        "@sentry/core": "10.51.0",
-        "@sentry/node-core": "10.51.0",
-        "@sentry/opentelemetry": "10.51.0",
+        "@sentry/core": "10.52.0",
+        "@sentry/node-core": "10.52.0",
+        "@sentry/opentelemetry": "10.52.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -4710,13 +4797,13 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.51.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.51.0.tgz",
-      "integrity": "sha512-VP9DMEzBEuauABrfDHYz/pRYa74M09uRJLz0ls3yel3sKhYHMyCB29ZxbKcciUhD4d33dwgi8DbaPZV2H/wnfQ==",
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.52.0.tgz",
+      "integrity": "sha512-IG7MBtLRPQ2LuU+kbD14AFZroZgAeUmJQTP1FI/F8n56O31+p+9R703LuBTpvZr6sm+eRYDMWcGYYkfLHRVjwg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.51.0",
-        "@sentry/opentelemetry": "10.51.0",
+        "@sentry/core": "10.52.0",
+        "@sentry/opentelemetry": "10.52.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -4751,31 +4838,13 @@
         }
       }
     },
-    "node_modules/@sentry/node-core/node_modules/@sentry/core": {
-      "version": "10.51.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
-      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/@sentry/core": {
-      "version": "10.51.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
-      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.51.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.51.0.tgz",
-      "integrity": "sha512-Qc7AlCE4uhB+SvHLqah4RgR1WdY7wmmr/hx9g/prDP9R1ocshmUEMrZK9qjuwaklW7/fmkFCXI8ETxo5L1bHIA==",
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.52.0.tgz",
+      "integrity": "sha512-Sc7StsvC0bwhMcgDfTRWUIexO5cNzzKUurvUwtpgQUnxO7AzexU3lkY3yHYDsCbWYAEQMXAgQYQtbcqoh+Ie7g==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.51.0"
+        "@sentry/core": "10.52.0"
       },
       "engines": {
         "node": ">=18"
@@ -4787,23 +4856,14 @@
         "@opentelemetry/semantic-conventions": "^1.39.0"
       }
     },
-    "node_modules/@sentry/opentelemetry/node_modules/@sentry/core": {
-      "version": "10.51.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
-      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@sentry/react": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.50.0.tgz",
-      "integrity": "sha512-MZHYjEZAtFIa4zPrWS4oXlo+gMppRvfETqUqF920Sj2jN2U7WjboU03lDmjfDqEcH7QiwjQyl13jHd2nwAyrrw==",
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.52.0.tgz",
+      "integrity": "sha512-2m72QCsja2cJJHD0ALxRnVt0qMEC2FV4LSi6AAiEdEG4lTb6mgcxavx5pJrW90jE+6dMGPbUz4q8c9vi4jh1qQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.50.0",
-        "@sentry/core": "10.50.0"
+        "@sentry/browser": "10.52.0",
+        "@sentry/core": "10.52.0"
       },
       "engines": {
         "node": ">=18"
@@ -4838,9 +4898,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-a11y": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.3.5.tgz",
-      "integrity": "sha512-5k6lpgfIeLxvNhE8v3wEzdiu73ONKjF4gmH1AHvfqYd8kIVzQJai0KCDxgvqNncXHQhIWkaf1fg6+9hKaYJyaw==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.3.6.tgz",
+      "integrity": "sha512-cbwXIT5CeHZ9AFbTKQ6YB7Ct6TAl/kKOgALbvzzVtFfRvm51JYygGaiJaB7PbPWn9wgJP2olJcFt+erlEc6cRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4852,20 +4912,20 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.5"
+        "storybook": "^10.3.6"
       }
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.3.5.tgz",
-      "integrity": "sha512-WuHbxia/o5TX4Rg/IFD0641K5qId/Nk0dxhmAUNoFs5L0+yfZUwh65XOBbzXqrkYmYmcVID4v7cgDRmzstQNkA==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.3.6.tgz",
+      "integrity": "sha512-TvIdADVPtauxW0LzXIpIv7X6GxwetorhyNh+6+7MHC27XSBCWVxxRUwL63YeLlHTuXsIk0quG3b1xgwVRzWOJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "10.3.5",
+        "@storybook/csf-plugin": "10.3.6",
         "@storybook/icons": "^2.0.1",
-        "@storybook/react-dom-shim": "10.3.5",
+        "@storybook/react-dom-shim": "10.3.6",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -4875,13 +4935,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.5"
+        "storybook": "^10.3.6"
       }
     },
     "node_modules/@storybook/addon-onboarding": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-onboarding/-/addon-onboarding-10.3.5.tgz",
-      "integrity": "sha512-s3/gIy9Tqxji27iclLY+KSk8kGeow1JxXMl1lPLyu8n6XVvv+tFrUPhAvUTs+fVenG6JQEWc0uzpYBdFRWbMtw==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-onboarding/-/addon-onboarding-10.3.6.tgz",
+      "integrity": "sha512-Tys9eOFzCkBygfDWVRa2hpTQI5Y1HQt9ybkJIHdR16GASQ3fhyXVULHVRmGQLEGN+3n84JGvlU8CN9S/OBB1IQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4889,13 +4949,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.5"
+        "storybook": "^10.3.6"
       }
     },
     "node_modules/@storybook/addon-vitest": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-vitest/-/addon-vitest-10.3.5.tgz",
-      "integrity": "sha512-PQDeeMwoF55kvzlhFqVKOryBJskkVk71AbDh7F0y8PdRRxlGbTvIUkKXktHZWBdESo0dV6BkeVxGQ4ZpiFxirg==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-vitest/-/addon-vitest-10.3.6.tgz",
+      "integrity": "sha512-HXj7RrPJY+xzoNjL+xZu2oLw1fI5BA87Noh1NAXMPuECHR5R5fuRM/tTsJuIGXHFMO06FjSi/rekDIfCj1fL4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4910,7 +4970,7 @@
         "@vitest/browser": "^3.0.0 || ^4.0.0",
         "@vitest/browser-playwright": "^4.0.0",
         "@vitest/runner": "^3.0.0 || ^4.0.0",
-        "storybook": "^10.3.5",
+        "storybook": "^10.3.6",
         "vitest": "^3.0.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
@@ -4929,13 +4989,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.3.5.tgz",
-      "integrity": "sha512-i4KwCOKbhtlbQIbhm53+Kk7bMnxa0cwTn1pxmtA/x5wm1Qu7FrrBQV0V0DNjkUqzcSKo1CjspASJV/HlY0zYlw==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.3.6.tgz",
+      "integrity": "sha512-gpvR/sE4BcrFtmQZ+Ker7zD23oQzoVeqD9nF6cK6yzY+Q0svJXyX2EPmFG4y+EwygD5/vNzDpP84gGMut8VRwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "10.3.5",
+        "@storybook/csf-plugin": "10.3.6",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -4943,14 +5003,14 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.5",
+        "storybook": "^10.3.6",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.3.5.tgz",
-      "integrity": "sha512-qlEzNKxOjq86pvrbuMwiGD/bylnsXk1dg7ve0j77YFjEEchqtl7qTlrXvFdNaLA89GhW6D/EV6eOCu/eobPDgw==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.3.6.tgz",
+      "integrity": "sha512-9kBf7VRdRqTSIYo+rPtVn5yjYYyK8kP2QhEYx3oiXvfwy4RexmbJnhk/tXa/lNiTqukA1TqaWQ2+5MqF4fu6YQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4963,7 +5023,7 @@
       "peerDependencies": {
         "esbuild": "*",
         "rollup": "*",
-        "storybook": "^10.3.5",
+        "storybook": "^10.3.6",
         "vite": "*",
         "webpack": "*"
       },
@@ -4990,9 +5050,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/icons": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.0.1.tgz",
-      "integrity": "sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.0.2.tgz",
+      "integrity": "sha512-KZBCpXsshAIjczYNXR/rlxEtCUX/eAbpFNwKi8bcOomrLA4t/SyPz5RF+lVPO2oZBUE4sAkt43mfJUevQDSEEw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -5001,14 +5061,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.3.5.tgz",
-      "integrity": "sha512-tpLTLaVGoA6fLK3ReyGzZUricq7lyPaV2hLPpj5wqdXLV/LpRtAHClUpNoPDYSBjlnSjL81hMZijbkGC3mA+gw==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.3.6.tgz",
+      "integrity": "sha512-oZQZ6xayWe5IdHmFUTL0TL8rX/gpNNh9gWhT2vzW5eeUvlkVG/RBKdsja6Ndrk2s1D9vcnwiI6r6CNXy3IEEmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "10.3.5",
+        "@storybook/react-dom-shim": "10.3.6",
         "react-docgen": "^8.0.2",
         "react-docgen-typescript": "^2.2.2"
       },
@@ -5019,7 +5079,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.3.5",
+        "storybook": "^10.3.6",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -5029,9 +5089,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.3.5.tgz",
-      "integrity": "sha512-Gw8R7XZm0zSUH0XAuxlQJhmizsLzyD6x00KOlP6l7oW9eQHXGfxg3seNDG3WrSAcW07iP1/P422kuiriQlOv7g==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.3.6.tgz",
+      "integrity": "sha512-/Tu1gPu+Fw+zOnAGmxRmOD30FX3a04LxcTAKflEtdpmtIMVR5bA3qpjy+f5YhoyDCecbXyKmL1OeIU2FIIZHqQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5041,20 +5101,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.3.5"
+        "storybook": "^10.3.6"
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.3.5.tgz",
-      "integrity": "sha512-UB5sJHeh26bfd8sNMx2YPGYRYmErIdTRaLOT28m4bykQIa1l9IgVktsYg/geW7KsJU0lXd3oTbnUjLD+enpi3w==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.3.6.tgz",
+      "integrity": "sha512-tySQRc+8q7V2NkylQMNJjDV8zXy6tkxb8oDqw/DIhHhI9Xn77MTKVZ8Cihbo5NMm7HYTB6xDKr6wqdSMgdufYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "10.3.5",
-        "@storybook/react": "10.3.5",
+        "@storybook/builder-vite": "10.3.6",
+        "@storybook/react": "10.3.6",
         "empathic": "^2.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -5068,52 +5128,52 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.3.5",
+        "storybook": "^10.3.6",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
-      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.19.0",
+        "enhanced-resolve": "^5.21.0",
         "jiti": "^2.6.1",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.4"
+        "tailwindcss": "4.3.0"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
-      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-x64": "4.2.4",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
-      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
       "cpu": [
         "arm64"
       ],
@@ -5127,9 +5187,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
-      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
       "cpu": [
         "arm64"
       ],
@@ -5143,9 +5203,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
-      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
       "cpu": [
         "x64"
       ],
@@ -5159,9 +5219,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
-      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
       "cpu": [
         "x64"
       ],
@@ -5175,9 +5235,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
-      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
       "cpu": [
         "arm"
       ],
@@ -5191,9 +5251,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
-      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
       "cpu": [
         "arm64"
       ],
@@ -5207,9 +5267,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
-      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
       ],
@@ -5223,9 +5283,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
-      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
       "cpu": [
         "x64"
       ],
@@ -5239,9 +5299,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
-      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
       ],
@@ -5255,9 +5315,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
-      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -5272,10 +5332,10 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.8.1",
-        "@emnapi/runtime": "^1.8.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
         "@tybys/wasm-util": "^0.10.1",
         "tslib": "^2.8.1"
       },
@@ -5284,9 +5344,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
-      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
       "cpu": [
         "arm64"
       ],
@@ -5300,9 +5360,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
-      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
       "cpu": [
         "x64"
       ],
@@ -5316,14 +5376,14 @@
       }
     },
     "node_modules/@tailwindcss/vite": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
-      "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
+      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/node": "4.2.4",
-        "@tailwindcss/oxide": "4.2.4",
-        "tailwindcss": "4.2.4"
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "tailwindcss": "4.3.0"
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
@@ -5515,9 +5575,10 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -5571,9 +5632,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -6309,9 +6370,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -6319,12 +6380,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -6368,9 +6429,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.24",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
-      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -6430,9 +6491,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6574,9 +6635,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "funding": [
         {
           "type": "opencollective",
@@ -6858,9 +6919,9 @@
       }
     },
     "node_modules/conf/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6983,9 +7044,9 @@
       }
     },
     "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -7292,9 +7353,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.353",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
+      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -7304,9 +7365,9 @@
       "license": "MIT"
     },
     "node_modules/empathic": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
-      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7332,9 +7393,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
-      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.2.tgz",
+      "integrity": "sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -7623,9 +7684,9 @@
       }
     },
     "node_modules/fast-json-stringify": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.3.0.tgz",
-      "integrity": "sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.4.0.tgz",
+      "integrity": "sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==",
       "funding": [
         {
           "type": "github",
@@ -7671,9 +7732,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -7729,9 +7790,9 @@
       }
     },
     "node_modules/fastify/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7795,48 +7856,48 @@
       "license": "MIT"
     },
     "node_modules/filecoin-pin": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/filecoin-pin/-/filecoin-pin-0.20.0.tgz",
-      "integrity": "sha512-rWYJuW0B75LUMvUiUUR6F3iQmHdwVdV0RrmG3sljP3+gVCboYkc0xB80RWlT631xCDCncz/lmstBAQ9r+RbdKw==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/filecoin-pin/-/filecoin-pin-0.20.1.tgz",
+      "integrity": "sha512-prd0IniD04ycHYROlwRtaBbZcGuxdZUfDf4aLb1TT9GK6RB5+a2eVRBuNEv3bTUC31lsKIywYyDZGbJWVnw3eg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^17.0.0",
         "@chainsafe/libp2p-yamux": "^8.0.1",
         "@clack/prompts": "^1.0.1",
-        "@filoz/synapse-core": "^0.3.3",
-        "@filoz/synapse-sdk": "^0.40.2",
+        "@filoz/synapse-core": "^0.4.1",
+        "@filoz/synapse-sdk": "^0.40.4",
         "@helia/block-brokers": "^5.1.3",
         "@helia/unixfs": "^7.0.4",
         "@ipld/car": "^5.4.2",
-        "@libp2p/identify": "^4.0.12",
-        "@libp2p/tcp": "^11.0.12",
+        "@libp2p/identify": "^4.1.2",
+        "@libp2p/tcp": "^11.0.17",
         "@multiformats/multiaddr": "^13.0.1",
         "@multiformats/multiaddr-to-uri": "^12.0.0",
-        "@sentry/node": "^10.40.0",
+        "@sentry/node": "^10.49.0",
         "commander": "^14.0.3",
         "datastore-core": "^11.0.2",
-        "fastify": "^5.7.4",
+        "fastify": "^5.8.5",
         "helia": "^6.0.20",
         "interface-blockstore": "^6.0.1",
         "interface-store": "^7.0.1",
         "it-to-buffer": "^4.0.10",
-        "libp2p": "^3.1.5",
+        "libp2p": "^3.2.2",
         "multiformats": "^13.4.2",
         "p-queue": "^9.1.0",
         "picocolors": "^1.1.1",
         "pino": "^10.3.1",
         "semver": "^7.7.4",
         "varint": "^6.0.0",
-        "viem": "^2.46.3"
+        "viem": "^2.48.3"
       },
       "bin": {
         "filecoin-pin": "dist/cli.js"
       }
     },
     "node_modules/filecoin-pin/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7901,9 +7962,9 @@
       "license": "MIT"
     },
     "node_modules/find-my-way": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz",
-      "integrity": "sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -8154,9 +8215,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8512,9 +8573,9 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
-      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -8578,6 +8639,17 @@
         "uint8arrays": "^5.1.0"
       }
     },
+    "node_modules/ipfs-unixfs/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
     "node_modules/ipns": {
       "version": "10.1.6",
       "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
@@ -8596,14 +8668,25 @@
         "uint8arrays": "^5.1.0"
       }
     },
+    "node_modules/ipns/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8721,9 +8804,9 @@
       "license": "MIT"
     },
     "node_modules/is-network-error": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
-      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -8941,9 +9024,9 @@
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-length-prefixed": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-10.0.1.tgz",
-      "integrity": "sha512-BhyluvGps26u9a7eQIpOI1YN7mFgi8lFwmiPi07whewbBARKAG9LE09Odc8s1Wtbt2MB6rNUrl7j9vvfXTJwdQ==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-10.0.2.tgz",
+      "integrity": "sha512-RrNBs4d7baK8AKGHleC55l/JtvzxDw6DPXs3CvFgQwdwFzLBFDvlpKgDDNDFwXJjPSy1nEX1A44nL110+EKc3g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-reader": "^6.0.1",
@@ -8951,10 +9034,6 @@
         "uint8-varint": "^2.0.1",
         "uint8arraylist": "^2.0.0",
         "uint8arrays": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/it-length-prefixed-stream": {
@@ -9049,9 +9128,9 @@
       }
     },
     "node_modules/it-pushable": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.3.tgz",
-      "integrity": "sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.4.tgz",
+      "integrity": "sha512-WSD7Ss4oCRfDZJT4ldLWr0Bom/muY90xxoJ5PQnU3uSKf0kxCOeehqZtiJX1ARqn+ymXGh1bxpDW9bDNHp2ivQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "p-defer": "^4.0.0"
@@ -9082,9 +9161,9 @@
       }
     },
     "node_modules/it-reader": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.4.tgz",
-      "integrity": "sha512-XCWifEcNFFjjBHtor4Sfaj8rcpt+FkY0L6WdhD578SCDhV4VUm7fCkF3dv5a+fTcfQqvN9BsxBTvWbYO6iCjTg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.5.tgz",
+      "integrity": "sha512-xdSVkCsVyWmKaE7ZIlqb1QbzitY7Zty7//F2YeZ/9Py5i3RzQHVoPqlHELH+1EouumUdPyfuKoANJ7Q5w4IEBg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-stream-types": "^2.0.1",
@@ -9255,9 +9334,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9395,9 +9474,9 @@
       }
     },
     "node_modules/kysely": {
-      "version": "0.28.16",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.16.tgz",
-      "integrity": "sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==",
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
+      "integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -9413,22 +9492,22 @@
       }
     },
     "node_modules/libp2p": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-3.2.3.tgz",
-      "integrity": "sha512-sri0KjdVrzKlahFqrMC/v0wsmvbpIasM0yA1jCAM4d5+Xjj1IN4yFzksSIVqKu6pqhhggR+Pr2ZgTBkH3BlpMw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-3.3.0.tgz",
+      "integrity": "sha512-FMonvlUUqLnxoX+TDJspUIHulWQMuDgAp1s31Lpev5AU6vryF/w2sv07yftClmk69yFuw7nDgJOXYhvQS/QCLg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.1.0",
         "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/crypto": "^5.1.17",
+        "@libp2p/crypto": "^5.1.18",
         "@libp2p/interface": "^3.2.2",
-        "@libp2p/interface-internal": "^3.1.3",
-        "@libp2p/logger": "^6.2.6",
-        "@libp2p/multistream-select": "^7.0.18",
-        "@libp2p/peer-collections": "^7.0.18",
-        "@libp2p/peer-id": "^6.0.8",
-        "@libp2p/peer-store": "^12.0.18",
-        "@libp2p/utils": "^7.1.0",
+        "@libp2p/interface-internal": "^3.1.4",
+        "@libp2p/logger": "^6.2.7",
+        "@libp2p/multistream-select": "^7.0.19",
+        "@libp2p/peer-collections": "^7.0.19",
+        "@libp2p/peer-id": "^6.0.9",
+        "@libp2p/peer-store": "^12.0.19",
+        "@libp2p/utils": "^7.2.0",
         "@multiformats/dns": "^1.0.6",
         "@multiformats/multiaddr": "^13.0.1",
         "@multiformats/multiaddr-matcher": "^3.0.1",
@@ -9855,9 +9934,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9932,9 +10011,9 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.3.tgz",
-      "integrity": "sha512-1h3lbVrE6hGf1e/764HfhPGg/bGrWMJDDh7G2rc4gFYZboVuI40BlG/y+UhtbhQDNlO/csMvrcnK0YrTlHUVew==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
+      "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -9945,7 +10024,6 @@
         "@babel/traverse": "^7.29.0",
         "@babel/types": "^7.29.0",
         "accepts": "^2.0.0",
-        "chalk": "^4.0.0",
         "ci-info": "^2.0.0",
         "connect": "^3.6.5",
         "debug": "^4.4.0",
@@ -9958,18 +10036,18 @@
         "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.84.3",
-        "metro-cache": "0.84.3",
-        "metro-cache-key": "0.84.3",
-        "metro-config": "0.84.3",
-        "metro-core": "0.84.3",
-        "metro-file-map": "0.84.3",
-        "metro-resolver": "0.84.3",
-        "metro-runtime": "0.84.3",
-        "metro-source-map": "0.84.3",
-        "metro-symbolicate": "0.84.3",
-        "metro-transform-plugins": "0.84.3",
-        "metro-transform-worker": "0.84.3",
+        "metro-babel-transformer": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-cache-key": "0.84.4",
+        "metro-config": "0.84.4",
+        "metro-core": "0.84.4",
+        "metro-file-map": "0.84.4",
+        "metro-resolver": "0.84.4",
+        "metro-runtime": "0.84.4",
+        "metro-source-map": "0.84.4",
+        "metro-symbolicate": "0.84.4",
+        "metro-transform-plugins": "0.84.4",
+        "metro-transform-worker": "0.84.4",
         "mime-types": "^3.0.1",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
@@ -9986,15 +10064,15 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.3.tgz",
-      "integrity": "sha512-svAA+yMLpeMiGcz/jKJs4oHpIGEx4nBqNEJ5AGj4CYIg1efvK+A0TjR6tgIuc6tKO5e8JmN/1lglpN2+f3/z/w==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
+      "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
         "hermes-parser": "0.35.0",
-        "metro-cache-key": "0.84.3",
+        "metro-cache-key": "0.84.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -10017,24 +10095,24 @@
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.3.tgz",
-      "integrity": "sha512-0QElxwLaHqLZf+Xqio8QrjVbuXP/8sJfQBGSPiITlKDVXrVLefuzYVSH9Sj+QL6lrPj2gYZd/iwQh1yZuVKnLA==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
+      "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
       "license": "MIT",
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
         "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.84.3"
+        "metro-core": "0.84.4"
       },
       "engines": {
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.3.tgz",
-      "integrity": "sha512-TnSL1Fdvrw+2glTdBSRmA5TL8l/i16ECjsrUdf3E5HncA+sNx8KcwDG8r+3ct1UhfYcusJypzZqTN55FZZcwGg==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
+      "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -10044,18 +10122,18 @@
       }
     },
     "node_modules/metro-config": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.3.tgz",
-      "integrity": "sha512-JmCzZWOETR+O22q8oPBWyQppx3roU9EbkbGzD8Gf1jukQ4b5T1fTzqqHruu6K4sTiNq5zVQySmKF6bp4kVARew==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
+      "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
       "license": "MIT",
       "dependencies": {
         "connect": "^3.6.5",
         "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.7.0",
-        "metro": "0.84.3",
-        "metro-cache": "0.84.3",
-        "metro-core": "0.84.3",
-        "metro-runtime": "0.84.3",
+        "metro": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-core": "0.84.4",
+        "metro-runtime": "0.84.4",
         "yaml": "^2.6.1"
       },
       "engines": {
@@ -10063,23 +10141,23 @@
       }
     },
     "node_modules/metro-core": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.3.tgz",
-      "integrity": "sha512-cc0pvAa80ai1nDmqqz0P59a+0ZqCZ/YHU/3jEekZL6spFnYDfX8iDLdn9FR6kX+67rmzKxHNrbrSRFLX2AYocw==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
+      "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.84.3"
+        "metro-resolver": "0.84.4"
       },
       "engines": {
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.3.tgz",
-      "integrity": "sha512-1cL4m4Jv1yRUt9RJExZQLfccscdlMNOcRG6LHLtmJhf3BG9j3MujPVc7CIpKYdFl+KUl+sdjge6oO3+meKCHQA==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
+      "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -10097,9 +10175,9 @@
       }
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.3.tgz",
-      "integrity": "sha512-3ofrG2OQyJbO9RNhCfOcl8QU7EE2WrSsnN5dFkuZaJO5+4Imujr9bUXmspeNlXRsOVk0F/rVRbEFH98lFSCkBQ==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
+      "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
@@ -10110,9 +10188,9 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.3.tgz",
-      "integrity": "sha512-pjEzGDtoM8DTHAIPK/9u9ZxszEiuRohYUVImWvgbnB91V4gqYJpQcoEYUugf2NIm1lrX5HNu0OvNqWmPBnGYjA==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
+      "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -10122,9 +10200,9 @@
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.3.tgz",
-      "integrity": "sha512-o7HLRfMyVk9N2dUZ9VjQfB6xxUItL9Pi9WcqxURE7MEKOH6wbGt9/E92YdYLluTOtkzYAEVfdC6h6lcxqA+hMQ==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
+      "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
@@ -10135,18 +10213,18 @@
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.3.tgz",
-      "integrity": "sha512-jS48CeSzw78M8y6VE0f9uy3lVmfbOS677j2VCxnlmlYmnahcXuC6IhoN9K6LynNvos9517yUadcfgioju38xYQ==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.0",
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.84.3",
+        "metro-symbolicate": "0.84.4",
         "nullthrows": "^1.1.1",
-        "ob1": "0.84.3",
+        "ob1": "0.84.4",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -10155,14 +10233,14 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.3.tgz",
-      "integrity": "sha512-J9Tpo8NCycYrozRvBIUyOwGAu4xkawOsAppmTscFiaegK0WvuDGwIM53GbzVSnytCHjVAF0io5GQxpkrKTuc7g==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
+      "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.84.3",
+        "metro-source-map": "0.84.4",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -10175,9 +10253,9 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.3.tgz",
-      "integrity": "sha512-8S3baq2XhBaafHEH5Q8sJW6tmzsEJk80qKc3RU/nZV1MsnYq94RdjTUR6AyKjQd6Rfsk1BtBxhtiNnk7mgslCg==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
+      "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -10192,9 +10270,9 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.3.tgz",
-      "integrity": "sha512-Wjba7PyYktNRsHbPmkx2J2UX32rAzcDXjCu49zPHeF/viJlYJhwRaNePQcHaCRqQ+kmgQT4ThprsnJfDj71ZMA==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
+      "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -10202,13 +10280,13 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.84.3",
-        "metro-babel-transformer": "0.84.3",
-        "metro-cache": "0.84.3",
-        "metro-cache-key": "0.84.3",
-        "metro-minify-terser": "0.84.3",
-        "metro-source-map": "0.84.3",
-        "metro-transform-plugins": "0.84.3",
+        "metro": "0.84.4",
+        "metro-babel-transformer": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-cache-key": "0.84.4",
+        "metro-minify-terser": "0.84.4",
+        "metro-source-map": "0.84.4",
+        "metro-transform-plugins": "0.84.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -10473,9 +10551,9 @@
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
       "funding": [
         {
           "type": "github",
@@ -10515,9 +10593,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -10527,9 +10605,9 @@
       }
     },
     "node_modules/node-abi/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10539,9 +10617,9 @@
       }
     },
     "node_modules/node-datachannel": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.29.0.tgz",
-      "integrity": "sha512-aCRJA5uZRqxMvQAl2QtOnCkodF1qJa1dCUVaXW9D7rku2p6F7PWe5OuRLcIgOYe+e2ZyJu0LefIQ95TtCn6xxA==",
+      "version": "0.32.3",
+      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.32.3.tgz",
+      "integrity": "sha512-Aok1ZhLsll472lRefgWYuWJ0070jh0ecHravTdRyZEmoESumebMEQV8Y+poBwSW2ZbEwAokAOGsK5Cu8pDDT2g==",
       "hasInstallScript": true,
       "license": "MPL 2.0",
       "dependencies": {
@@ -10621,9 +10699,9 @@
       "license": "MIT"
     },
     "node_modules/ob1": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.3.tgz",
-      "integrity": "sha512-J7554Ef8bzmKaDY365Afq6PF+qtdnY/d5PKUQFrsKlZHV/N3OGZewVrvDrQDyX5V5NJjTpcAKtlrFZcDr+HvpQ==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
+      "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -10944,9 +11022,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -11100,9 +11178,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -11128,9 +11206,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -11279,14 +11357,14 @@
       }
     },
     "node_modules/protons-runtime": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.1.tgz",
-      "integrity": "sha512-ONL+jDj143WA1m+WKLuuqBIaDKxm32dx6HfJdyujrRcni/6KkhXzVnyg22nH/Wwqmbwnd1BKUVkD1hMEWZFeww==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.6.0.tgz",
+      "integrity": "sha512-/Kde+sB9DsMFrddJT/UZWe6XqvL7SL5dbag/DBCElFKhkwDj7XKt53S+mzLyaDP5OqS0wXjV5SA572uWDaT0Hg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
+        "uint8-varint": "^2.0.2",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^5.0.1"
       }
     },
     "node_modules/proxy-from-env": {
@@ -11454,9 +11532,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -11527,16 +11605,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {
@@ -11547,19 +11625,18 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.85.2.tgz",
-      "integrity": "sha512-GFWEPwLYirfj5X8gMtXOWtqX0cqUEURRHETZfFk37VCa4++izrKvGvv24anvuyulXV87NAhVkfNw93rLg3HByw==",
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.85.3.tgz",
+      "integrity": "sha512-HN/fGC+3nZVcDNcw7gfbM/DuqZAvI9Mz+/SxuhODaua4JY0BPzhfTzWXRyTR4mRgMHmShTPpH2PYMTxvZrsdZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@react-native/assets-registry": "0.85.2",
-        "@react-native/codegen": "0.85.2",
-        "@react-native/community-cli-plugin": "0.85.2",
-        "@react-native/gradle-plugin": "0.85.2",
-        "@react-native/js-polyfills": "0.85.2",
-        "@react-native/normalize-colors": "0.85.2",
-        "@react-native/virtualized-lists": "0.85.2",
+        "@react-native/assets-registry": "0.85.3",
+        "@react-native/codegen": "0.85.3",
+        "@react-native/community-cli-plugin": "0.85.3",
+        "@react-native/gradle-plugin": "0.85.3",
+        "@react-native/js-polyfills": "0.85.3",
+        "@react-native/normalize-colors": "0.85.3",
+        "@react-native/virtualized-lists": "0.85.3",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
@@ -11570,8 +11647,8 @@
         "hermes-compiler": "250829098.0.10",
         "invariant": "^2.2.4",
         "memoize-one": "^5.0.0",
-        "metro-runtime": "^0.84.0",
-        "metro-source-map": "^0.84.0",
+        "metro-runtime": "^0.84.3",
+        "metro-source-map": "^0.84.3",
         "nullthrows": "^1.1.1",
         "pretty-format": "^29.7.0",
         "promise": "^8.3.0",
@@ -11593,7 +11670,7 @@
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       },
       "peerDependencies": {
-        "@react-native/jest-preset": "0.85.2",
+        "@react-native/jest-preset": "0.85.3",
         "@types/react": "^19.1.1",
         "react": "^19.2.3"
       },
@@ -11694,9 +11771,9 @@
       }
     },
     "node_modules/react-native/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11981,9 +12058,9 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -11997,33 +12074,39 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -12516,9 +12599,9 @@
       "license": "MIT"
     },
     "node_modules/storybook": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.3.5.tgz",
-      "integrity": "sha512-uBSZu/GZa9aEIW3QMGvdQPMZWhGxSe4dyRWU8B3/Vd47Gy/XLC7tsBxRr13txmmPOEDHZR94uLuq0H50fvuqBw==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.3.6.tgz",
+      "integrity": "sha512-vbSz7g/1rGMC1uAULqMZjALkIuLu2QABqfhRYhyr/11kzyesi+vAmwyJLukZP1FfecxGOgMwOh6GS0YsGpHAvQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -12545,10 +12628,14 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "prettier": "^2 || ^3"
+        "prettier": "^2 || ^3",
+        "vite-plus": "^0.1.15"
       },
       "peerDependenciesMeta": {
         "prettier": {
+          "optional": true
+        },
+        "vite-plus": {
           "optional": true
         }
       }
@@ -12586,9 +12673,9 @@
       }
     },
     "node_modules/storybook/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -12792,9 +12879,9 @@
       }
     },
     "node_modules/tailwind-merge": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
-      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -12802,9 +12889,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -12898,9 +12985,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
-      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -12922,16 +13009,22 @@
       "license": "MIT"
     },
     "node_modules/thread-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
-      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.1.0.tgz",
+      "integrity": "sha512-Bw6h2iBDt16v6iHLChBIoVYU8CBo9GPsW8TG7h1hRVhqKhIkH6N8qkxNSmiOZTKsCLPbtWG4ViWLkU6KeKXpig==",
       "license": "MIT",
       "dependencies": {
-        "real-require": "^0.2.0"
+        "real-require": "^1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "node_modules/throat": {
       "version": "5.0.0",
@@ -12984,9 +13077,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13030,22 +13123,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.29",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
-      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.29"
+        "tldts-core": "^7.0.30"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.29",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
-      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -13232,9 +13325,9 @@
       }
     },
     "node_modules/uint8-varint": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.4.tgz",
-      "integrity": "sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "uint8arraylist": "^2.0.0",
@@ -13272,9 +13365,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.1.0.tgz",
-      "integrity": "sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.2.0.tgz",
+      "integrity": "sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -13450,9 +13543,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.48.4",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.4.tgz",
-      "integrity": "sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==",
+      "version": "2.48.11",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.11.tgz",
+      "integrity": "sha512-+WZ5E0dBS6GtKb+1wEk5DeYRRRW42+pFnXCo67Ydodf42sBwO+hu3wnQy66lc4MKmHz+llPVdbyehYr9oTE2iw==",
       "funding": [
         {
           "type": "github",
@@ -13550,9 +13643,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13817,16 +13910,16 @@
       }
     },
     "node_modules/webcrypto-core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
-      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+      "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-schema": "^2.7.0",
         "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.7.0"
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/webidl-conversions": {
@@ -14096,9 +14189,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -14150,9 +14243,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@filoz/synapse-core": "0.4.1",
+    "@filoz/synapse-sdk": "0.40.4",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-form": "^0.1.8",
@@ -34,7 +36,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.14",
-    "viem": "^2.0.0"
+    "viem": "^2.47.12"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.5",

--- a/src/lib/filecoin-pin/synapse.ts
+++ b/src/lib/filecoin-pin/synapse.ts
@@ -1,5 +1,8 @@
-import { initializeSynapse } from 'filecoin-pin/core/synapse'
+import { AddPiecesPermission, CreateDataSetPermission, fromSecp256k1 } from '@filoz/synapse-core/session-key'
+import { calibration, Synapse } from '@filoz/synapse-sdk'
+import { initializeSynapse, type SynapseSetupConfig } from 'filecoin-pin/core/synapse'
 import pino from 'pino'
+import { createClient, custom, getAddress, type HttpTransport, http, type WebSocketTransport, webSocket } from 'viem'
 
 const logger = pino({
   level: 'debug',
@@ -8,20 +11,101 @@ const logger = pino({
   },
 })
 
-import type { SynapseSetupConfig } from 'filecoin-pin/core/synapse'
+const APPLICATION_SOURCE = 'filecoin-pin'
+const WEBSOCKET_REGEX = /^ws(s)?:\/\//i
+
+function createTransport(rpcUrl: string): HttpTransport | WebSocketTransport {
+  return WEBSOCKET_REGEX.test(rpcUrl) ? webSocket(rpcUrl) : http(rpcUrl)
+}
+
+function isSessionKeyConfig(
+  config: SynapseSetupConfig
+): config is Extract<SynapseSetupConfig, { sessionKey: `0x${string}` }> {
+  return (
+    'walletAddress' in config &&
+    'sessionKey' in config &&
+    config.walletAddress != null &&
+    config.sessionKey != null &&
+    !('readOnly' in config && config.readOnly === true)
+  )
+}
+
+const REQUIRED_PERMISSIONS = [CreateDataSetPermission, AddPiecesPermission]
 
 /**
- * Synapse type derived from filecoin-pin's re-export to avoid dual-copy
- * type incompatibility between the website's and filecoin-pin's
- * @filoz/synapse-sdk installations.
+ * Inline session-key init that bypasses `Synapse.create`'s permission check.
+ *
+ * The SDK's `Synapse.create` requires the session key to hold ALL four
+ * `DefaultFwssPermissions` (CreateDataSet, AddPieces, SchedulePieceRemovals,
+ * DeleteDataSet) at construction time. We only authorize CreateDataSet +
+ * AddPieces on-chain (least privilege), so we go through the public
+ * `Synapse` constructor directly.
+ *
+ * `syncExpirations` is narrowed to the permissions we actually grant; we
+ * still validate them ourselves so a misconfigured / expired session key
+ * fails fast instead of silently breaking writes later.
  */
-export type Synapse = Awaited<ReturnType<typeof initializeSynapse>>
+async function initSessionKeySynapse(
+  config: Extract<SynapseSetupConfig, { sessionKey: `0x${string}` }>
+): Promise<Synapse> {
+  const chain = config.chain ?? calibration
+  const rpcUrl = config.rpcUrl ?? chain.rpcUrls.default.webSocket?.[0] ?? chain.rpcUrls.default.http[0]
+  const transport = rpcUrl ? createTransport(rpcUrl) : http()
+
+  const walletAddress = getAddress(config.walletAddress)
+
+  const sessionKey = fromSecp256k1({
+    privateKey: config.sessionKey,
+    root: walletAddress,
+    chain,
+    transport,
+  })
+
+  await sessionKey.syncExpirations(REQUIRED_PERMISSIONS)
+  if (!sessionKey.hasPermissions(REQUIRED_PERMISSIONS)) {
+    throw new Error(
+      'Session key is missing or has expired permissions for CreateDataSet and/or AddPieces. ' +
+        'Re-authorize via scripts/create-session-key.sh and update VITE_SESSION_KEY.'
+    )
+  }
+
+  const resolved = transport({ chain, retryCount: 0 })
+  const client = createClient({
+    chain,
+    transport: custom({ request: resolved.request }),
+    account: walletAddress,
+    name: 'Synapse Client',
+    key: 'synapse-client',
+  })
+
+  logger.info(
+    { event: 'synapse.init', mode: 'session-key-bypass', chain: chain.name },
+    'Initializing Synapse (session key, bypassing DefaultFwssPermissions check)'
+  )
+
+  return new Synapse({
+    client,
+    sessionClient: sessionKey.client,
+    source: APPLICATION_SOURCE,
+    withCDN: config.withCDN ?? false,
+  })
+}
+
+export type { Synapse }
 
 let synapsePromise: Promise<Synapse> | null = null
 
 export const getSynapseClient = (config: SynapseSetupConfig) => {
   if (!synapsePromise) {
-    synapsePromise = initializeSynapse(config, logger)
+    const promise = isSessionKeyConfig(config) ? initSessionKeySynapse(config) : initializeSynapse(config, logger)
+    // Clear the cached rejected promise so the next caller can retry instead
+    // of receiving the same stale failure forever.
+    promise.catch(() => {
+      if (synapsePromise === promise) {
+        synapsePromise = null
+      }
+    })
+    synapsePromise = promise
   }
 
   return synapsePromise


### PR DESCRIPTION
## What changed

The session-key auth path in `src/lib/filecoin-pin/synapse.ts` now calls `Synapse`'s public constructor directly instead of `Synapse.create`.

`Synapse.create` in `@filoz/synapse-sdk@0.40.3` ([synapse.ts:61](https://github.com/filoz/synapse-sdk/blob/main/src/synapse.ts#L61)) checks the session key for all four `DefaultFwssPermissions` (`CreateDataSet`, `AddPieces`, `SchedulePieceRemovals`, `DeleteDataSet`) at construction time and throws otherwise. pin.filecoin.cloud authorizes only `CreateDataSet` + `AddPieces` on-chain, so every flow (including read-only balance fetch) threw `"Session key does not have the required permissions"`.

The inline init replicates what `Synapse.create` does and skips only that check. It also narrows `syncExpirations` to the two permissions the key actually holds.

## Dependency changes

* Pin `@filoz/synapse-sdk@0.40.4` and `@filoz/synapse-core@0.4.1` to exact versions, matching what `filecoin-pin@0.20.0` declares. The workaround binds to the constructor surface, so floats add risk, and matching filecoin-pin's exact range keeps the dep graph deduped without `overrides`.
* Bump direct `viem` to `^2.47.12` to satisfy the SDK peer.
* Regenerate `package-lock.json`.

## How to verify

1. `npm ci`
2. `npm run typecheck && npm run lint && npm test && npm run build`
3. Set `VITE_WALLET_ADDRESS` + `VITE_SESSION_KEY` (session key with `CreateDataSet` + `AddPieces` only). Run `npm run dev` and load the site. Wallet balance renders without the permission error.

## Notes / risks

* The constructor must keep parity with `Synapse.create` minus the permission check. Exact version pinning protects against silent drift.
* `syncExpirations` runs at init, so transient RPC failure can poison the singleton. `getSynapseClient` clears the cached promise on rejection so the next caller retries.

## Follow-up

File an upstream issue on `@filoz/synapse-sdk` to add a configurable `requiredPermissions` option, or move the check to point of use.
