### PR TITLE
chore: fix package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7011,7 +7011,6 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -11629,6 +11628,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.85.3.tgz",
       "integrity": "sha512-HN/fGC+3nZVcDNcw7gfbM/DuqZAvI9Mz+/SxuhODaua4JY0BPzhfTzWXRyTR4mRgMHmShTPpH2PYMTxvZrsdZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-native/assets-registry": "0.85.3",
         "@react-native/codegen": "0.85.3",


### PR DESCRIPTION
just ran `npm i` with nodejs 24 on latest main.. package-lock.json gets an update... this is that update.