### PR TITLE
fix: restore ?providerId URL parameter for provider targeting

### DIFF
--- a/src/context/filecoin-pin-provider.tsx
+++ b/src/context/filecoin-pin-provider.tsx
@@ -3,7 +3,7 @@ import { type DataSetState, useDataSetManager } from '../hooks/use-data-set-mana
 import { filecoinPinConfig } from '../lib/filecoin-pin/config.ts'
 import { getSynapseClient, type Synapse } from '../lib/filecoin-pin/synapse.ts'
 import { fetchWalletSnapshot, type WalletSnapshot } from '../lib/filecoin-pin/wallet.ts'
-import { getDebugParams, logDebugParams } from '../utils/debug-params.ts'
+import { type DebugParams, getDebugParams, logDebugParams } from '../utils/debug-params.ts'
 
 type WalletState =
   | { status: 'idle'; data?: WalletSnapshot }
@@ -18,6 +18,7 @@ export interface FilecoinPinContextValue {
   dataSet: DataSetState
   checkIfDatasetExists: () => Promise<bigint[]>
   addDataSetId: (id: bigint) => void
+  debugParams: DebugParams
 }
 
 export const FilecoinPinContext = createContext<FilecoinPinContextValue | undefined>(undefined)
@@ -87,8 +88,9 @@ export const FilecoinPinProvider = ({ children }: { children: ReactNode }) => {
       dataSet,
       checkIfDatasetExists,
       addDataSetId,
+      debugParams,
     }),
-    [wallet, refreshWallet, dataSet, checkIfDatasetExists, addDataSetId]
+    [wallet, refreshWallet, dataSet, checkIfDatasetExists, addDataSetId, debugParams]
   )
 
   return <FilecoinPinContext.Provider value={value}>{children}</FilecoinPinContext.Provider>

--- a/src/hooks/use-filecoin-upload.test.ts
+++ b/src/hooks/use-filecoin-upload.test.ts
@@ -1,0 +1,79 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { executeUploadMock, checkUploadReadinessMock, createCarFromFileMock, useFilecoinPinContextMock } = vi.hoisted(
+  () => ({
+    executeUploadMock: vi.fn(),
+    checkUploadReadinessMock: vi.fn(),
+    createCarFromFileMock: vi.fn(),
+    useFilecoinPinContextMock: vi.fn(),
+  })
+)
+
+vi.mock('filecoin-pin/core/upload', () => ({
+  executeUpload: executeUploadMock,
+  checkUploadReadiness: checkUploadReadinessMock,
+}))
+
+vi.mock('filecoin-pin/core/unixfs', () => ({
+  createCarFromFile: createCarFromFileMock,
+}))
+
+vi.mock('./use-filecoin-pin-context.ts', () => ({
+  useFilecoinPinContext: useFilecoinPinContextMock,
+}))
+
+vi.mock('./use-ipni-check.ts', () => ({
+  cacheIpniResult: vi.fn(),
+}))
+
+import { useFilecoinUpload } from './use-filecoin-upload.ts'
+
+const baseContext = {
+  synapse: {},
+  wallet: { status: 'ready', data: { address: '0xabc' } },
+  addDataSetId: vi.fn(),
+  debugParams: { providerId: null, dataSetId: null },
+}
+
+const testFile = new File(['hello'], 'a.txt')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  createCarFromFileMock.mockResolvedValue({
+    rootCid: { toString: () => 'bafyrootcid' },
+    carBytes: new Uint8Array([1, 2, 3]),
+  })
+  checkUploadReadinessMock.mockResolvedValue({ status: 'ready' })
+  executeUploadMock.mockResolvedValue({ copies: [], network: 'calibration' })
+})
+
+describe('useFilecoinUpload providerId debug param', () => {
+  const getOpts = () => executeUploadMock.mock.lastCall?.at(-1)
+
+  it('forwards debugParams.providerId to executeUpload as providerIds=[BigInt(n)]', async () => {
+    useFilecoinPinContextMock.mockReturnValue({
+      ...baseContext,
+      debugParams: { providerId: 6, dataSetId: null },
+    })
+
+    const { result } = renderHook(() => useFilecoinUpload())
+    await result.current.uploadFile(testFile)
+
+    expect(executeUploadMock).toHaveBeenCalledTimes(1)
+    expect(getOpts()).toMatchObject({ providerIds: [BigInt(6)] })
+  })
+
+  it('omits providerIds when debugParams.providerId is null so Synapse auto-selects', async () => {
+    useFilecoinPinContextMock.mockReturnValue({
+      ...baseContext,
+      debugParams: { providerId: null, dataSetId: null },
+    })
+
+    const { result } = renderHook(() => useFilecoinUpload())
+    await result.current.uploadFile(testFile)
+
+    expect(executeUploadMock).toHaveBeenCalledTimes(1)
+    expect(getOpts()).not.toHaveProperty('providerIds')
+  })
+})

--- a/src/hooks/use-filecoin-upload.ts
+++ b/src/hooks/use-filecoin-upload.ts
@@ -53,7 +53,7 @@ export const INPI_ERROR_MESSAGE =
  * - Tracks IPNI availability and on-chain confirmation
  */
 export const useFilecoinUpload = () => {
-  const { synapse, wallet, addDataSetId } = useFilecoinPinContext()
+  const { synapse, wallet, addDataSetId, debugParams } = useFilecoinPinContext()
 
   // Waitable ref so the upload callback can access synapse even if initialized after callback creation
   const synapseRef = useWaitableRef(synapse)
@@ -134,6 +134,7 @@ export const useFilecoinUpload = () => {
         const result = await executeUpload(synapse, carResult.carBytes, carResult.rootCid, {
           logger,
           contextId: `upload-${Date.now()}`,
+          ...(debugParams.providerId != null && { providerIds: [BigInt(debugParams.providerId)] }),
           pieceMetadata: {
             ...(metadata ?? {}),
             label: file.name,
@@ -283,7 +284,7 @@ export const useFilecoinUpload = () => {
         }))
       }
     },
-    [updateStepState, synapseRef, wallet, addDataSetId]
+    [updateStepState, synapseRef, wallet, addDataSetId, debugParams]
   )
 
   const resetUpload = useCallback(() => {

--- a/src/utils/debug-params.ts
+++ b/src/utils/debug-params.ts
@@ -24,7 +24,7 @@
  * multiple providers without losing your default data set.
  */
 
-interface DebugParams {
+export interface DebugParams {
   providerId: number | null
   dataSetId: number | null
 }


### PR DESCRIPTION
## Summary

- `?providerId=N` stopped working after the filecoin-pin 0.18 upgrade (#154)
- The refactor moved storage context creation from `useDataSetManager` into `executeUpload`, but `providerId` was never wired up to the new call site — it was parsed but silently ignored
- Fix: expose `debugParams` via `FilecoinPinContext` and pass `providerIds` to `executeUpload` when `?providerId` is set

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (24 tests)
- [ ] Manual: open `/?providerId=6`, upload a file, confirm upload targets provider 6