### PR TITLE
fix: parse providerId URL param safely as bigint to prevent overflow

### DIFF
--- a/src/hooks/use-data-set-manager.ts
+++ b/src/hooks/use-data-set-manager.ts
@@ -12,7 +12,7 @@ interface UseDataSetManagerProps {
   synapse: Synapse | null
   walletAddress: string | null
   debugParams?: {
-    providerId?: number | null
+    providerId?: bigint | null
     dataSetId?: number | null
   }
 }

--- a/src/hooks/use-filecoin-upload.test.ts
+++ b/src/hooks/use-filecoin-upload.test.ts
@@ -54,7 +54,7 @@ describe('useFilecoinUpload providerId debug param', () => {
   it('forwards debugParams.providerId to executeUpload as providerIds=[BigInt(n)]', async () => {
     useFilecoinPinContextMock.mockReturnValue({
       ...baseContext,
-      debugParams: { providerId: 6, dataSetId: null },
+      debugParams: { providerId: 6n, dataSetId: null },
     })
 
     const { result } = renderHook(() => useFilecoinUpload())

--- a/src/hooks/use-filecoin-upload.ts
+++ b/src/hooks/use-filecoin-upload.ts
@@ -134,7 +134,7 @@ export const useFilecoinUpload = () => {
         const result = await executeUpload(synapse, carResult.carBytes, carResult.rootCid, {
           logger,
           contextId: `upload-${Date.now()}`,
-          ...(debugParams.providerId != null && { providerIds: [BigInt(debugParams.providerId)] }),
+          ...(debugParams.providerId != null && { providerIds: [debugParams.providerId] }),
           pieceMetadata: {
             ...(metadata ?? {}),
             label: file.name,

--- a/src/utils/debug-params.test.ts
+++ b/src/utils/debug-params.test.ts
@@ -3,7 +3,7 @@ import { getDebugParams } from './debug-params.ts'
 
 const UNSAFE_INTEGER_PROVIDER_ID = '9007199254740993'
 
-describe('getDebugParams providerId', () => {
+describe('getDebugParams', () => {
   const originalLocation = window.location
 
   beforeEach(() => {

--- a/src/utils/debug-params.test.ts
+++ b/src/utils/debug-params.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDebugParams } from './debug-params.ts'
+
+const UNSAFE_INTEGER_PROVIDER_ID = String(Number.MAX_SAFE_INTEGER + 1)
+
+describe('getDebugParams providerId', () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    vi.stubGlobal('location', { ...originalLocation, search: '' })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const setSearch = (search: string) => {
+    vi.stubGlobal('location', { ...originalLocation, search })
+  }
+
+  it('returns null when providerId is absent', () => {
+    setSearch('')
+    expect(getDebugParams().providerId).toBeNull()
+  })
+
+  it('parses providerId as bigint without Number precision loss', () => {
+    setSearch(`?providerId=${UNSAFE_INTEGER_PROVIDER_ID}`)
+    expect(getDebugParams().providerId).toBe(BigInt(UNSAFE_INTEGER_PROVIDER_ID))
+  })
+
+  it('returns null for invalid providerId values', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(vi.fn())
+
+    setSearch('?providerId=abc')
+    expect(getDebugParams().providerId).toBeNull()
+
+    setSearch('?providerId=0')
+    expect(getDebugParams().providerId).toBeNull()
+
+    setSearch('?providerId=-5')
+    expect(getDebugParams().providerId).toBeNull()
+
+    setSearch('?providerId=')
+    expect(getDebugParams().providerId).toBeNull()
+
+    warn.mockRestore()
+  })
+})

--- a/src/utils/debug-params.test.ts
+++ b/src/utils/debug-params.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDebugParams } from './debug-params.ts'
 
-const UNSAFE_INTEGER_PROVIDER_ID = String(Number.MAX_SAFE_INTEGER + 1)
+const UNSAFE_INTEGER_PROVIDER_ID = '9007199254740993'
 
 describe('getDebugParams providerId', () => {
   const originalLocation = window.location

--- a/src/utils/debug-params.ts
+++ b/src/utils/debug-params.ts
@@ -25,8 +25,39 @@
  */
 
 export interface DebugParams {
-  providerId: number | null
+  providerId: bigint | null
   dataSetId: number | null
+}
+
+/** Decimal integer string only; avoids Number precision loss for large provider IDs. */
+const PROVIDER_ID_PATTERN = /^\d+$/
+
+const parseQueryParamBigInt = (value: string | null): bigint | null => {
+  if (value === null) {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (trimmed === '') {
+    return null
+  }
+
+  if (!PROVIDER_ID_PATTERN.test(trimmed)) {
+    console.warn(`[DEBUG PARAMS] Invalid providerId: ${value}`)
+    return null
+  }
+
+  try {
+    const parsed = BigInt(trimmed)
+    if (parsed <= 0n) {
+      console.warn(`[DEBUG PARAMS] providerId must be > 0: ${value}`)
+      return null
+    }
+    return parsed
+  } catch {
+    console.warn(`[DEBUG PARAMS] Invalid providerId: ${value}`)
+    return null
+  }
 }
 
 const parseQueryParamNumber = (value: string | null): number | null => {
@@ -57,7 +88,7 @@ export function getDebugParams(): DebugParams {
   const dataSetId = params.get('dataSetId')
 
   // Use URL providerId if present, otherwise defer to Synapse for selection
-  const providerId = parseQueryParamNumber(providerIdParam)
+  const providerId = parseQueryParamBigInt(providerIdParam)
 
   return {
     providerId,


### PR DESCRIPTION
### Description
This PR resolves issue #182 by ensuring that the `providerId` URL query parameter is parsed safely and directly into a `BigInt`, eliminating the intermediate conversion into a standard JavaScript `number`. 

Previously, parsing the raw string via standard JS numbers caused silent precision loss and unexpected behavior for Filecoin provider IDs that exceed `Number.MAX_SAFE_INTEGER` (9007199254740991).

### Changes
* **`src/utils/debug-params.ts`**: Introduced `parseQueryParamBigInt` utility to handle input trimming, decimal-only digit validation (`/^\d+$/`), direct `BigInt()` invocation, and `> 0n` verification. It gracefully degrades to `null` on empty or malformed parameters without crashing the application.
* **`src/hooks/use-filecoin-upload.ts`**: Updated hook to forward the parsed `bigint | null` parameter straight to `executeUpload`.
* **`src/hooks/use-data-set-manager.ts`**: Adjusted internal type references to match `bigint | null`.
* **`src/utils/debug-params.test.ts`**: Created new comprehensive unit tests validating standard behavior, empty params, malformed inputs, and edge-case provider IDs exceeding `Number.MAX_SAFE_INTEGER`.
* **`src/hooks/use-filecoin-upload.test.ts`**: Adjusted existing mock specifications to fit the new types properly.

### Verification Done
* All formatting rules strictly enforced specifically to the changed files.
* Ran local verification test suite (`npm run test`) successfully passing all 29 tests.