### PR TITLE
ci: update auto-label workflow to use pull_request_target

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -3,7 +3,9 @@ name: Auto-label issues and PRs
 on:
   issues:
     types: [opened]
-  pull_request:
+  # We do pull_request_target instead of pull_request to support PR's from forks.  
+  # This is safe here because we're not checking out or executing any code from the fork; we're just adding labels.
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
Change pull_request to pull_request_target for safety with forked PRs. This matches https://github.com/filecoin-project/filecoin-pin/blob/master/.github/workflows/auto-label.yml