### PR TITLE
fix: isolate uploads per browser on the shared demo wallet

### DIFF
--- a/src/context/filecoin-pin-provider.tsx
+++ b/src/context/filecoin-pin-provider.tsx
@@ -3,6 +3,7 @@ import { type DataSetState, useDataSetManager } from '../hooks/use-data-set-mana
 import { filecoinPinConfig } from '../lib/filecoin-pin/config.ts'
 import { getSynapseClient, type Synapse } from '../lib/filecoin-pin/synapse.ts'
 import { fetchWalletSnapshot, type WalletSnapshot } from '../lib/filecoin-pin/wallet.ts'
+import { getOrCreateClientId } from '../lib/local-storage/client-id.ts'
 import { type DebugParams, getDebugParams, logDebugParams } from '../utils/debug-params.ts'
 
 type WalletState =
@@ -26,6 +27,11 @@ export const FilecoinPinContext = createContext<FilecoinPinContextValue | undefi
 const initialWalletState: WalletState = { status: 'idle' }
 
 export const FilecoinPinProvider = ({ children }: { children: ReactNode }) => {
+  // Ensure this browser has a stable client id (and run the one-time legacy
+  // shared-data-set cleanup) synchronously on first render, before the history
+  // effect reads stored data set ids.
+  useState(getOrCreateClientId)
+
   const [wallet, setWallet] = useState<WalletState>(initialWalletState)
   const synapseRef = useRef<Synapse | null>(null)
   const config = filecoinPinConfig

--- a/src/context/filecoin-pin-provider.tsx
+++ b/src/context/filecoin-pin-provider.tsx
@@ -3,7 +3,6 @@ import { type DataSetState, useDataSetManager } from '../hooks/use-data-set-mana
 import { filecoinPinConfig } from '../lib/filecoin-pin/config.ts'
 import { getSynapseClient, type Synapse } from '../lib/filecoin-pin/synapse.ts'
 import { fetchWalletSnapshot, type WalletSnapshot } from '../lib/filecoin-pin/wallet.ts'
-import { getOrCreateClientId } from '../lib/local-storage/client-id.ts'
 import { type DebugParams, getDebugParams, logDebugParams } from '../utils/debug-params.ts'
 
 type WalletState =
@@ -27,11 +26,6 @@ export const FilecoinPinContext = createContext<FilecoinPinContextValue | undefi
 const initialWalletState: WalletState = { status: 'idle' }
 
 export const FilecoinPinProvider = ({ children }: { children: ReactNode }) => {
-  // Ensure this browser has a stable client id (and run the one-time legacy
-  // shared-data-set cleanup) synchronously on first render, before the history
-  // effect reads stored data set ids.
-  useState(getOrCreateClientId)
-
   const [wallet, setWallet] = useState<WalletState>(initialWalletState)
   const synapseRef = useRef<Synapse | null>(null)
   const config = filecoinPinConfig

--- a/src/hooks/use-filecoin-upload.ts
+++ b/src/hooks/use-filecoin-upload.ts
@@ -3,6 +3,7 @@ import { createCarFromFile } from 'filecoin-pin/core/unixfs'
 import { checkUploadReadiness, executeUpload, type UploadExecutionResult } from 'filecoin-pin/core/upload'
 import pino from 'pino'
 import { useCallback, useState } from 'react'
+import { getOrCreateClientId } from '../lib/local-storage/client-id.ts'
 import { addStoredDataSetId } from '../lib/local-storage/data-set.ts'
 import type { StepState } from '../types/upload/step.ts'
 import { formatFileSize } from '../utils/format-file-size.ts'
@@ -135,6 +136,10 @@ export const useFilecoinUpload = () => {
           logger,
           contextId: `upload-${Date.now()}`,
           ...(debugParams.providerId != null && { providerIds: [BigInt(debugParams.providerId)] }),
+          // Per-browser metadata so Synapse smart-select gives this browser its
+          // own data set instead of sharing the demo wallet's data sets with
+          // every other visitor (avoids cross-user file visibility + RPC blowup).
+          metadata: { clientId: getOrCreateClientId() },
           pieceMetadata: {
             ...(metadata ?? {}),
             label: file.name,

--- a/src/lib/local-storage/client-id.ts
+++ b/src/lib/local-storage/client-id.ts
@@ -1,0 +1,56 @@
+/**
+ * Per-browser client identity.
+ *
+ * The demo runs on a single shared wallet, so without a discriminator every
+ * visitor's uploads land in the same Synapse data set(s) (matched by the
+ * default `source` / `withIPFSIndexing` metadata). That makes the history view
+ * show other users' files and makes it enumerate hundreds of pieces on load.
+ *
+ * We inject this `clientId` as data-set-level metadata at upload time. Synapse
+ * smart-select matches data sets by *exact* metadata equality, so a unique
+ * clientId forces this browser into its OWN data set (created on first upload,
+ * reused afterwards) and never matches anyone else's.
+ */
+
+const CLIENT_ID_KEY = 'filecoin-pin-client-id'
+
+/**
+ * Return this browser's stable client id, creating one on first use.
+ *
+ * The first time a client id is created we also drop any legacy (shared) data
+ * set ids so the history view stops loading datasets that predate per-browser
+ * isolation.
+ */
+export const getOrCreateClientId = (): string => {
+  try {
+    let id = localStorage.getItem(CLIENT_ID_KEY)
+    if (!id) {
+      id = crypto.randomUUID()
+      localStorage.setItem(CLIENT_ID_KEY, id)
+      clearLegacyDataSetIds()
+    }
+    return id
+  } catch (error) {
+    // localStorage/crypto unavailable (e.g. SSR or locked-down browser):
+    // fall back to an ephemeral id so uploads still get their own data set.
+    console.warn('[ClientId] Falling back to ephemeral client id:', error)
+    return crypto.randomUUID()
+  }
+}
+
+/** Remove all previously-stored (shared) data set id keys. One-time migration. */
+const clearLegacyDataSetIds = (): void => {
+  const toRemove: string[] = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key?.includes('filecoin-pin-data-set-id')) {
+      toRemove.push(key)
+    }
+  }
+  for (const key of toRemove) {
+    localStorage.removeItem(key)
+  }
+  if (toRemove.length > 0) {
+    console.debug('[ClientId] Cleared legacy shared data set ids:', toRemove.join(', '))
+  }
+}

--- a/src/lib/local-storage/client-id.ts
+++ b/src/lib/local-storage/client-id.ts
@@ -23,16 +23,18 @@ const CLIENT_ID_KEY = 'filecoin-pin-client-id'
  */
 export const getOrCreateClientId = (): string => {
   try {
-    let id = localStorage.getItem(CLIENT_ID_KEY)
-    if (!id) {
-      id = crypto.randomUUID()
-      localStorage.setItem(CLIENT_ID_KEY, id)
+    const existing = localStorage.getItem(CLIENT_ID_KEY)
+    if (existing) return existing
+
+    const id = crypto.randomUUID()
+    localStorage.setItem(CLIENT_ID_KEY, id)
+    try {
       clearLegacyDataSetIds()
+    } catch (error) {
+      console.warn('[ClientId] Failed to clear legacy data set ids:', error)
     }
     return id
   } catch (error) {
-    // localStorage/crypto unavailable (e.g. SSR or locked-down browser):
-    // fall back to an ephemeral id so uploads still get their own data set.
     console.warn('[ClientId] Falling back to ephemeral client id:', error)
     return crypto.randomUUID()
   }


### PR DESCRIPTION
https://github.com/filecoin-project/filecoin-pin-website/issues/166#issuecomment-4610674373

In addition, it conflicts with part 179. This is only a temporary solution. If we feel it is not necessary or wait for 179, we can turn this off directly.


  ### Behavior change / regression context

  Before `16116ba1dfb2c46c8e5ff79179302457c1d74e2d`, the shared demo wallet still behaved like “one data set per browser”: a new browser with no local data set id created a fresh data set, stored that id in
  localStorage, and reused only that browser’s data set on later uploads/history loads.

  `16116ba` upgraded the upload flow to `filecoin-pin` / Synapse smart-select for multi-copy uploads. That removed the previous explicit localStorage-driven data set creation/reuse path. Because every visitor
  uses the same demo wallet and the same default data-set metadata, smart-select can match/reuse the same data sets across browsers. The visible regression is that a new/private browser can see files uploaded
  by other visitors, and history loading has to enumerate much larger shared data sets, causing the RPC spike tracked in #166.

  This PR restores the pre-`16116ba` isolation model as a temporary fix until #179 changes the product model. Each browser gets a stable local `clientId`, and uploads include it as data-set-level metadata.
  Since Synapse matches data sets by exact metadata, each browser creates/reuses its own data set pair instead of matching other visitors’ shared-wallet data sets. Old locally stored shared data set ids are
  cleared on first `clientId` creation so existing browsers stop loading pre-isolation history.


after

  | Type | Count | What it is |
  |---|---|---|
  | Multicall3 `aggregate3` (`0xcA11…CA11`) | ~290 | smart-select scanning candidate data sets (5 field-reads each) |
  | `eth_getBalance` / approvals / allowances | ~10 | readiness + allowance preflight |
  | `pdp/ping` | 2 | liveness probe for the 2 providers |
  | `piece/uploads`, `piece/pull` | a few | upload CAR / secondary copy pull |
  | `data-sets/create-and-add` | 2 | create the 2 new data sets (carry `clientId`) |
  | `data-sets/created/0x…` | ~20 | poll for create-data-set tx confirmation |
  | `pieces/added/0x…` | a few | poll for add-pieces confirmation |
  | `filecoinpin.contact/cid/…` | a few | IPNI / retrievability check |
  | `betterstackdata.com/metrics` | 1 | telemetry |