### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: 5
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+  - package-ecosystem: npm
+    directory: /
+    open-pull-requests-limit: 5
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      filecoin:
+        patterns:
+          - "filecoin-pin"
+          - "@filoz/*"
+      all-other-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "filecoin-pin"
+          - "@filoz/*"
+    ignore:
+      - dependency-name: "@biomejs/biome"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` for automated dependency update PRs
- Weekly npm checks, monthly GitHub Actions checks
- Groups `filecoin-pin` and `@filoz/*` separately so their update PRs are never crowded out by other dependencies
- Inspired by the config in the `filecoin-pin` repo, with grouping added

## Test plan
- [ ] Verify Dependabot picks up the config and starts opening PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)