### PR TITLE
fix: rotate expired demo session key in config defaults

### DIFF
--- a/src/lib/filecoin-pin/config.ts
+++ b/src/lib/filecoin-pin/config.ts
@@ -7,9 +7,9 @@ const normalizeEnvValue = (value: string | boolean | number | undefined) => {
   return trimmed.length === 0 ? undefined : trimmed
 }
 
-// Hardcoded defaults (can be overridden by env vars) expires: 2026-02-01 16:37:53
+// Hardcoded defaults (can be overridden by env vars) expires: 2026-08-15 09:24:22
 const DEFAULT_WALLET_ADDRESS: Hex = '0x44f08D1beFe61255b3C3A349C392C560FA333759'
-const DEFAULT_SESSION_KEY: Hex = '0xca3c92749c4c31beb64ea4334a719b813af1b54b8449a12c81d583018a252af8'
+const DEFAULT_SESSION_KEY: Hex = '0x416dc827726298c032acf086ddf45c1de79b8e62f3af2ffe0377afe08862deb3'
 
 const privateKey = normalizeEnvValue(import.meta.env.VITE_FILECOIN_PRIVATE_KEY) as Hex | undefined
 const envWalletAddress = normalizeEnvValue(import.meta.env.VITE_WALLET_ADDRESS) as Hex | undefined


### PR DESCRIPTION
### What changed

`DEFAULT_SESSION_KEY` in `src/lib/filecoin-pin/config.ts` expired 2026-02-01, which broke session-key auth on the IPFS/ENS deploy ([pin.filecoincloud.eth.limo](https://pin.filecoincloud.eth.limo)). That static build has no runtime env to override the default, so the baked-in key is the only auth it has. This rotates it to a key valid through 2026-08-15. Owner wallet (`0x44f08D…3759`) is unchanged.

### How to verify

On-chain (calibration), both delegated permissions for the session key resolve to a future expiry. The registry is resolved from Warm Storage (`sessionKeyRegistry()`); session address derives from the key:

```bash
cast call 0x518411c2062E119Aaf7A8B12A2eDf9a939347655 \
  "authorizationExpiry(address,address,bytes32)(uint256)" \
  0x44f08D1beFe61255b3C3A349C392C560FA333759 \
  0xa20F4A04FBb13c9Ca11e711c3Fcfd757C5B8ec7c \
  0x25ebf20299107c91b4624d5bac3a16d32cabf0db23b450ee09ab7732983b1dc9 \
  --rpc-url https://api.calibration.node.glif.io/rpc/v1
# -> 1786800262 (CreateDataSet, 2026-08-15); AddPieces typehash returns the same
```

App-level: run `npm run dev` with no `VITE_WALLET_ADDRESS` / `VITE_SESSION_KEY` set, upload a file. It pins and replicates without the "session key expired or expiring soon" error (verified: 2x-replicated, Data Set 14149 + 14150).

### Notes / risks

This is a delegated session key (`CreateDataSet` + `AddPieces` only) on the calibration demo wallet, committed on purpose so the IPFS deploy carries auth in the bundle. Next rotation due 2026-08-15 per [`docs/update-session-key.md`](docs/update-session-key.md).
