### PR TITLE
fix: link IPFS root CIDs without file path

### DIFF
--- a/src/components/upload/car-upload-and-ipni-card.tsx
+++ b/src/components/upload/car-upload-and-ipni-card.tsx
@@ -46,7 +46,7 @@ export const CarUploadAndIpniCard = ({ stepStates, cid, fileName }: CarUploadAnd
           subtitle={
             <TextWithCopyToClipboard
               text={cid}
-              {...(!hasIpniAnnounceFailure && { href: getIpfsGatewayRenderLink(cid, fileName) })}
+              {...(!hasIpniAnnounceFailure && { href: getIpfsGatewayRenderLink(cid) })}
             />
           }
           title="IPFS Root CID"

--- a/src/components/upload/upload-completed.tsx
+++ b/src/components/upload/upload-completed.tsx
@@ -98,7 +98,7 @@ function UploadCompleted({
             hasIpniFailure ? (
               <TextWithCopyToClipboard text={cid} />
             ) : (
-              <TextWithCopyToClipboard href={getIpfsGatewayRenderLink(cid, fileName)} text={cid} />
+              <TextWithCopyToClipboard href={getIpfsGatewayRenderLink(cid)} text={cid} />
             )
           }
           title="IPFS Root CID"

--- a/src/utils/links.test.ts
+++ b/src/utils/links.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { getIpfsGatewayDownloadLink, getIpfsGatewayRenderLink } from './links.ts'
+
+describe('IPFS gateway links', () => {
+  it('links directly to the root CID without treating the file name as a path', () => {
+    expect(getIpfsGatewayRenderLink('bafyroot')).toBe('https://dweb.link/ipfs/bafyroot')
+  })
+
+  it('keeps the original file name in the download query only', () => {
+    const href = getIpfsGatewayDownloadLink('bafyroot', 'Screenshot 2026-05-18 at 7.48.15 pm.png')
+
+    expect(href).toBe('https://dweb.link/ipfs/bafyroot?filename=Screenshot%202026-05-18%20at%207.48.15%20pm.png')
+    expect(href).not.toContain('/Screenshot')
+  })
+})

--- a/src/utils/links.test.ts
+++ b/src/utils/links.test.ts
@@ -7,10 +7,12 @@ describe('IPFS gateway links', () => {
     expect(getIpfsGatewayRenderLink('bafyroot')).toBe('https://dweb.link/ipfs/bafyroot')
   })
 
-  it('keeps the original file name in the download query only', () => {
+  it('keeps the original file name in the download query and forces attachment disposition', () => {
     const href = getIpfsGatewayDownloadLink('bafyroot', 'Screenshot 2026-05-18 at 7.48.15 pm.png')
 
-    expect(href).toBe('https://dweb.link/ipfs/bafyroot?filename=Screenshot%202026-05-18%20at%207.48.15%20pm.png')
+    expect(href).toBe(
+      'https://dweb.link/ipfs/bafyroot?filename=Screenshot%202026-05-18%20at%207.48.15%20pm.png&download=true',
+    )
     expect(href).not.toContain('/Screenshot')
   })
 })

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -8,7 +8,7 @@ const UPLOAD_COMPLETED_LINKS = {
  * download button href
  */
 export const getIpfsGatewayDownloadLink = (cid: string, fileName: string): string => {
-  return `${getIpfsGatewayRenderLink(cid)}?filename=${encodeURIComponent(fileName)}`
+  return `${getIpfsGatewayRenderLink(cid)}?filename=${encodeURIComponent(fileName)}&download=true`
 }
 
 /**

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -8,14 +8,14 @@ const UPLOAD_COMPLETED_LINKS = {
  * download button href
  */
 export const getIpfsGatewayDownloadLink = (cid: string, fileName: string): string => {
-  return `${getIpfsGatewayRenderLink(cid, fileName)}?filename=${fileName}.car`
+  return `${getIpfsGatewayRenderLink(cid)}?filename=${encodeURIComponent(fileName)}`
 }
 
 /**
  * cid text hyperlink
  */
-export const getIpfsGatewayRenderLink = (cid: string, fileName: string): string => {
-  return `${UPLOAD_COMPLETED_LINKS.ipfsGatewayBaseUrl}${cid}/${fileName}`
+export const getIpfsGatewayRenderLink = (cid: string): string => {
+  return `${UPLOAD_COMPLETED_LINKS.ipfsGatewayBaseUrl}${cid}`
 }
 
 /**


### PR DESCRIPTION
## Summary
**Simply put, previously transmitted files or images have never been properly previewed or downloaded**


Fix IPFS gateway links for uploaded single-file root CIDs.

Single-file uploads produce a root CID for the file itself, not a directory CID. The UI previously linked to:

`/ipfs/{cid}/{fileName}`

which makes gateways look for `{fileName}` under the CID and returns a 404 like:

`path /... was not found under the CID`

This updates the UI to link directly to:

`/ipfs/{cid}`

and keeps the original file name only in the download query string.

## Changes

- Stop appending `fileName` as a path segment in IPFS root CID links
- Encode the download `filename` query parameter
- Update upload completion/progress cards to use the root CID link directly
- Add regression tests for IPFS gateway link generation

## Testing

- `npm test -- --run src/utils/links.test.ts src/hooks/use-filecoin-upload.test.ts`
- `npm run typecheck`
- `npm run lint`