### PR TITLE
fix: stop RPC traffic from scaling with the shared wallet's dataset count

### DIFF
--- a/src/context/filecoin-pin-provider.tsx
+++ b/src/context/filecoin-pin-provider.tsx
@@ -3,6 +3,7 @@ import { type DataSetState, useDataSetManager } from '../hooks/use-data-set-mana
 import { filecoinPinConfig } from '../lib/filecoin-pin/config.ts'
 import { getSynapseClient, type Synapse } from '../lib/filecoin-pin/synapse.ts'
 import { fetchWalletSnapshot, type WalletSnapshot } from '../lib/filecoin-pin/wallet.ts'
+import { getOrCreateClientId } from '../lib/local-storage/client-id.ts'
 import { type DebugParams, getDebugParams, logDebugParams } from '../utils/debug-params.ts'
 
 type WalletState =
@@ -38,29 +39,41 @@ export const FilecoinPinProvider = ({ children }: { children: ReactNode }) => {
     debugParams,
   })
 
+  const refreshInFlightRef = useRef<Promise<void> | null>(null)
+
   const refreshWallet = useCallback(async () => {
+    // Dedupe concurrent calls (StrictMode double-invokes the mount effect in
+    // dev) so the snapshot is fetched once.
+    if (refreshInFlightRef.current) return refreshInFlightRef.current
+
     setWallet((prev) => ({
       status: 'loading',
       data: prev.status === 'ready' ? prev.data : undefined,
     }))
 
-    try {
-      const synapse = await getSynapseClient(config)
-      synapseRef.current = synapse
+    const refresh = (async () => {
+      try {
+        const synapse = await getSynapseClient(config)
+        synapseRef.current = synapse
 
-      const snapshot = await fetchWalletSnapshot(synapse)
-      setWallet({
-        status: 'ready',
-        data: snapshot,
-      })
-    } catch (error) {
-      console.error('Failed to load wallet balances', error)
-      setWallet((prev) => ({
-        status: 'error',
-        error: error instanceof Error ? error.message : 'Unable to load wallet balances. See console for details.',
-        data: prev.data,
-      }))
-    }
+        const snapshot = await fetchWalletSnapshot(synapse)
+        setWallet({
+          status: 'ready',
+          data: snapshot,
+        })
+      } catch (error) {
+        console.error('Failed to load wallet balances', error)
+        setWallet((prev) => ({
+          status: 'error',
+          error: error instanceof Error ? error.message : 'Unable to load wallet balances. See console for details.',
+          data: prev.data,
+        }))
+      } finally {
+        refreshInFlightRef.current = null
+      }
+    })()
+    refreshInFlightRef.current = refresh
+    return refresh
   }, [])
 
   useEffect(() => {
@@ -69,6 +82,11 @@ export const FilecoinPinProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     logDebugParams()
+    // Establish the per-browser client id before any dataset lookups run. On
+    // first creation this also purges legacy shared-wallet dataset ids from
+    // localStorage, so the history view never enumerates the communal
+    // datasets that predate per-browser isolation.
+    getOrCreateClientId()
   }, [])
 
   // Proactively check for existing data set when prerequisites are ready,

--- a/src/hooks/use-dataset-pieces.test.ts
+++ b/src/hooks/use-dataset-pieces.test.ts
@@ -1,0 +1,105 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getDetailedDataSetMock, useFilecoinPinContextMock } = vi.hoisted(() => ({
+  getDetailedDataSetMock: vi.fn(),
+  useFilecoinPinContextMock: vi.fn(),
+}))
+
+vi.mock('filecoin-pin/core/data-set', () => ({
+  getDetailedDataSet: getDetailedDataSetMock,
+}))
+
+vi.mock('./use-filecoin-pin-context.ts', () => ({
+  useFilecoinPinContext: useFilecoinPinContextMock,
+}))
+
+import { setCachedPieces } from '../lib/local-storage/piece-cache.ts'
+import { type DatasetPiece, useDatasetPieces } from './use-dataset-pieces.ts'
+
+const WALLET = '0xabc'
+
+const readyWallet = { status: 'ready', data: { address: WALLET, network: 'calibration' } }
+
+const makeContext = (dataSet: { status: string; dataSetIds?: bigint[] }) => ({
+  wallet: readyWallet,
+  synapse: {},
+  dataSet,
+})
+
+const cachedPiece = (pieceCid: string): DatasetPiece =>
+  ({
+    id: `piece-${pieceCid}`,
+    pieceCid,
+    cid: 'bafyroot',
+    fileName: 'a.txt',
+    fileSize: '5 B',
+    providerName: 'p',
+    datasetId: '1',
+    providerId: '4',
+    serviceURL: '',
+    transactionHash: '',
+    network: 'calibration',
+    uploadedAt: 0,
+    pieceId: 1,
+  }) as DatasetPiece
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  getDetailedDataSetMock.mockResolvedValue({ pieces: [], provider: null })
+})
+
+describe('useDatasetPieces auto-load', () => {
+  it('does not enumerate the chain when a dataset id appears mid-upload on a fresh browser', async () => {
+    // Fresh browser: dataset manager has resolved ready with no ids, cache empty.
+    useFilecoinPinContextMock.mockReturnValue(makeContext({ status: 'ready', dataSetIds: [] }))
+    const { rerender } = renderHook(() => useDatasetPieces())
+
+    // Mid-upload, piecesConfirmed appends the freshly created dataset id,
+    // flipping dataSetIds 0 -> 1 while the cache is still empty (addPiece only
+    // writes at upload completion). History must NOT enumerate the chain here.
+    useFilecoinPinContextMock.mockReturnValue(makeContext({ status: 'ready', dataSetIds: [1n] }))
+    await act(async () => {
+      rerender()
+    })
+
+    expect(getDetailedDataSetMock).not.toHaveBeenCalled()
+  })
+
+  it('does not arm auto-load until the dataset manager is ready', async () => {
+    // While the dataset manager is still initializing with no ids, the effect
+    // must not mark itself loaded — otherwise the later idle->ready flip with
+    // real ids would never trigger the one allowed enumeration.
+    useFilecoinPinContextMock.mockReturnValue(makeContext({ status: 'initializing', dataSetIds: [] }))
+    const { rerender } = renderHook(() => useDatasetPieces())
+
+    useFilecoinPinContextMock.mockReturnValue(makeContext({ status: 'ready', dataSetIds: [7n] }))
+    await act(async () => {
+      rerender()
+    })
+
+    await waitFor(() => expect(getDetailedDataSetMock).toHaveBeenCalledTimes(1))
+    expect(getDetailedDataSetMock).toHaveBeenCalledWith(expect.anything(), 7n)
+  })
+
+  it('enumerates the chain once on load when ids are present and the cache is empty', async () => {
+    useFilecoinPinContextMock.mockReturnValue(makeContext({ status: 'ready', dataSetIds: [5n] }))
+
+    renderHook(() => useDatasetPieces())
+
+    await waitFor(() => expect(getDetailedDataSetMock).toHaveBeenCalledTimes(1))
+    expect(getDetailedDataSetMock).toHaveBeenCalledWith(expect.anything(), 5n)
+  })
+
+  it('renders from the cache without any chain enumeration', async () => {
+    setCachedPieces(WALLET, [cachedPiece('bafkcached')])
+    useFilecoinPinContextMock.mockReturnValue(makeContext({ status: 'ready', dataSetIds: [5n] }))
+
+    const { result } = renderHook(() => useDatasetPieces())
+
+    await waitFor(() => expect(result.current.hasLoaded).toBe(true))
+    expect(getDetailedDataSetMock).not.toHaveBeenCalled()
+    expect(result.current.pieces).toHaveLength(1)
+  })
+})

--- a/src/hooks/use-dataset-pieces.ts
+++ b/src/hooks/use-dataset-pieces.ts
@@ -1,5 +1,6 @@
 import { getDetailedDataSet } from 'filecoin-pin/core/data-set'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { addCachedPiece, getCachedPieces, setCachedPieces } from '../lib/local-storage/piece-cache.ts'
 import { useFilecoinPinContext } from './use-filecoin-pin-context.ts'
 
 // Inlined from @filoz/synapse-sdk METADATA_KEYS to avoid dual-copy type issues
@@ -41,7 +42,10 @@ export interface DatasetPiece {
 /**
  * Fetches and normalizes dataset pieces for the active wallet.
  *
- * Uses getDetailedDataSet which only needs Synapse + dataSetId.
+ * Renders from the localStorage piece cache when available (zero RPC calls);
+ * only falls back to chain enumeration (getDetailedDataSet) when no cache
+ * exists or the caller explicitly refreshes. Chain enumeration is expensive:
+ * several eth_calls per dataset plus one eth_call per piece for metadata.
  */
 export const useDatasetPieces = () => {
   const [pieces, setPieces] = useState<DatasetPiece[]>([])
@@ -50,6 +54,9 @@ export const useDatasetPieces = () => {
   const [hasLoaded, setHasLoaded] = useState(false)
 
   const { wallet, synapse, dataSet } = useFilecoinPinContext()
+
+  const walletAddress = wallet.status === 'ready' ? wallet.data.address : null
+  const network = wallet.status === 'ready' ? wallet.data.network : 'calibration'
 
   const dataSetIdsKey = dataSet.status === 'ready' ? dataSet.dataSetIds.map((id) => String(id)).join(',') : ''
   const dataSetIds = useMemo<bigint[]>(
@@ -84,7 +91,6 @@ export const useDatasetPieces = () => {
         })
       )
 
-      const network = wallet?.status === 'ready' ? wallet.data.network : 'calibration'
       // Group by pieceCid so the same piece replicated across N datasets renders as one entry
       const piecesByCid = new Map<string, DatasetPiece>()
 
@@ -149,6 +155,12 @@ export const useDatasetPieces = () => {
 
       console.debug('[DatasetPieces] Merged', merged.length, 'unique pieces across', dataSetIds.length, 'datasets')
       setPieces(merged)
+      // A failed dataset fetch yields a partial list; caching it would
+      // silently drop those pieces from history on every later visit.
+      const hadFailures = datasets.some((entry) => entry == null)
+      if (walletAddress && !hadFailures) {
+        setCachedPieces(walletAddress, merged)
+      }
     } catch (err) {
       console.error('[DatasetPieces] Failed to load pieces:', err)
       setError(err instanceof Error ? err.message : 'Failed to load pieces')
@@ -157,28 +169,50 @@ export const useDatasetPieces = () => {
       setIsLoading(false)
       setHasLoaded(true)
     }
-  }, [dataSetIds, wallet, synapse])
+  }, [dataSetIds, network, walletAddress, synapse])
 
+  // Load history at most once per page visit: from the localStorage cache when
+  // available (zero RPC calls), falling back to one chain enumeration when the
+  // cache is missing (e.g. cleared storage). Deliberately NOT re-run when the
+  // wallet object refreshes or when an upload appends a new dataset id —
+  // uploads update history locally via addPiece.
+  const autoLoadedRef = useRef(false)
   useEffect(() => {
-    if (synapse && dataSetIds.length > 0) {
-      loadPieces()
-    } else {
-      setPieces([])
-      setHasLoaded(false)
+    if (autoLoadedRef.current) return
+    if (!walletAddress || dataSetIds.length === 0) return
+
+    const cached = getCachedPieces(walletAddress)
+    if (cached) {
+      autoLoadedRef.current = true
+      console.debug('[DatasetPieces] Loaded', cached.length, 'pieces from cache (no RPC)')
+      setPieces(cached)
+      setHasLoaded(true)
+      return
     }
-  }, [loadPieces, synapse, dataSetIds.length])
+
+    if (synapse) {
+      autoLoadedRef.current = true
+      loadPieces()
+    }
+  }, [walletAddress, dataSetIds.length, synapse, loadPieces])
 
   const refreshPieces = useCallback(() => {
     loadPieces()
   }, [loadPieces])
 
   /** Add a piece to the history without refetching from backend (used after upload completes). */
-  const addPiece = useCallback((piece: DatasetPiece) => {
-    setPieces((prev) => {
-      const updated = [piece, ...prev]
-      return updated
-    })
-  }, [])
+  const addPiece = useCallback(
+    (piece: DatasetPiece) => {
+      setPieces((prev) => {
+        const updated = [piece, ...prev]
+        return updated
+      })
+      if (walletAddress) {
+        addCachedPiece(walletAddress, piece)
+      }
+    },
+    [walletAddress]
+  )
 
   return {
     pieces,

--- a/src/hooks/use-dataset-pieces.ts
+++ b/src/hooks/use-dataset-pieces.ts
@@ -179,7 +179,17 @@ export const useDatasetPieces = () => {
   const autoLoadedRef = useRef(false)
   useEffect(() => {
     if (autoLoadedRef.current) return
-    if (!walletAddress || dataSetIds.length === 0) return
+    // Only arm once the dataset manager has settled. While it is idle/
+    // initializing, dataSetIds is empty but not authoritative, so we must not
+    // mark ourselves loaded yet.
+    if (!walletAddress || dataSet.status !== 'ready') return
+    // A wallet that genuinely owns no datasets: arm the guard and stop, so a
+    // dataset id appended mid-upload (piecesConfirmed flips 0 -> 1 before the
+    // piece cache is written) never triggers a chain enumeration.
+    if (dataSetIds.length === 0) {
+      autoLoadedRef.current = true
+      return
+    }
 
     const cached = getCachedPieces(walletAddress)
     if (cached) {
@@ -194,7 +204,7 @@ export const useDatasetPieces = () => {
       autoLoadedRef.current = true
       loadPieces()
     }
-  }, [walletAddress, dataSetIds.length, synapse, loadPieces])
+  }, [walletAddress, dataSet.status, dataSetIds.length, synapse, loadPieces])
 
   const refreshPieces = useCallback(() => {
     loadPieces()

--- a/src/hooks/use-filecoin-upload.test.ts
+++ b/src/hooks/use-filecoin-upload.test.ts
@@ -1,14 +1,19 @@
 import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { executeUploadMock, checkUploadReadinessMock, createCarFromFileMock, useFilecoinPinContextMock } = vi.hoisted(
-  () => ({
-    executeUploadMock: vi.fn(),
-    checkUploadReadinessMock: vi.fn(),
-    createCarFromFileMock: vi.fn(),
-    useFilecoinPinContextMock: vi.fn(),
-  })
-)
+const {
+  executeUploadMock,
+  checkUploadReadinessMock,
+  createCarFromFileMock,
+  useFilecoinPinContextMock,
+  createFreshUploadContextsMock,
+} = vi.hoisted(() => ({
+  executeUploadMock: vi.fn(),
+  checkUploadReadinessMock: vi.fn(),
+  createCarFromFileMock: vi.fn(),
+  useFilecoinPinContextMock: vi.fn(),
+  createFreshUploadContextsMock: vi.fn(),
+}))
 
 vi.mock('filecoin-pin/core/upload', () => ({
   executeUpload: executeUploadMock,
@@ -27,6 +32,16 @@ vi.mock('./use-ipni-check.ts', () => ({
   cacheIpniResult: vi.fn(),
 }))
 
+vi.mock('../lib/filecoin-pin/synapse.ts', () => ({
+  ensureSessionKeyPermissions: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../lib/filecoin-pin/fresh-contexts.ts', () => ({
+  createFreshUploadContexts: createFreshUploadContextsMock,
+}))
+
+import { addStoredDataSetId, getStoredDataSetIds } from '../lib/local-storage/data-set.ts'
+import { getCachedPieces, setCachedPieces } from '../lib/local-storage/piece-cache.ts'
 import { useFilecoinUpload } from './use-filecoin-upload.ts'
 
 const baseContext = {
@@ -38,14 +53,18 @@ const baseContext = {
 
 const testFile = new File(['hello'], 'a.txt')
 
+const fakeContexts = [{ provider: { id: 4n, name: 'provider-a' } }, { provider: { id: 2n, name: 'provider-b' } }]
+
 beforeEach(() => {
   vi.clearAllMocks()
+  localStorage.clear()
   createCarFromFileMock.mockResolvedValue({
     rootCid: { toString: () => 'bafyrootcid' },
     carBytes: new Uint8Array([1, 2, 3]),
   })
   checkUploadReadinessMock.mockResolvedValue({ status: 'ready' })
   executeUploadMock.mockResolvedValue({ copies: [], network: 'calibration' })
+  createFreshUploadContextsMock.mockResolvedValue(fakeContexts)
 })
 
 describe('useFilecoinUpload providerId debug param', () => {
@@ -75,5 +94,105 @@ describe('useFilecoinUpload providerId debug param', () => {
 
     expect(executeUploadMock).toHaveBeenCalledTimes(1)
     expect(getOpts()).not.toHaveProperty('providerIds')
+  })
+})
+
+describe('useFilecoinUpload dataset resume', () => {
+  const getOpts = () => executeUploadMock.mock.lastCall?.at(-1)
+
+  it('passes stored dataset ids to executeUpload and omits metadata (skips smart-select)', async () => {
+    addStoredDataSetId('0xabc', 42)
+    addStoredDataSetId('0xabc', 77)
+    useFilecoinPinContextMock.mockReturnValue(baseContext)
+
+    const { result } = renderHook(() => useFilecoinUpload())
+    await result.current.uploadFile(testFile)
+
+    expect(executeUploadMock).toHaveBeenCalledTimes(1)
+    expect(getOpts()).toMatchObject({ dataSetIds: [42n, 77n] })
+    expect(getOpts()).not.toHaveProperty('metadata')
+  })
+
+  it('uses fresh contexts (no smart-select) when no dataset ids are stored', async () => {
+    useFilecoinPinContextMock.mockReturnValue(baseContext)
+
+    const { result } = renderHook(() => useFilecoinUpload())
+    await result.current.uploadFile(testFile)
+
+    expect(createFreshUploadContextsMock).toHaveBeenCalledTimes(1)
+    expect(executeUploadMock).toHaveBeenCalledTimes(1)
+    expect(getOpts()).toMatchObject({ contexts: fakeContexts })
+    expect(getOpts()).not.toHaveProperty('dataSetIds')
+    expect(getOpts()).not.toHaveProperty('metadata')
+  })
+
+  it('falls back to smart-select with clientId metadata when fresh context selection fails', async () => {
+    useFilecoinPinContextMock.mockReturnValue(baseContext)
+    createFreshUploadContextsMock.mockRejectedValueOnce(new Error('No reachable storage providers available'))
+
+    const { result } = renderHook(() => useFilecoinUpload())
+    await result.current.uploadFile(testFile)
+
+    expect(executeUploadMock).toHaveBeenCalledTimes(1)
+    expect(getOpts()).not.toHaveProperty('contexts')
+    expect(getOpts()?.metadata?.clientId).toBeTruthy()
+  })
+
+  it('clears stored ids and piece cache, then retries with fresh contexts when resume resolution fails', async () => {
+    addStoredDataSetId('0xabc', 42)
+    setCachedPieces('0xabc', [{ pieceCid: 'bafkstale' } as never])
+    useFilecoinPinContextMock.mockReturnValue(baseContext)
+    executeUploadMock
+      .mockRejectedValueOnce(new Error('Data set 42 does not exist'))
+      .mockResolvedValueOnce({ copies: [], network: 'calibration' })
+
+    const { result } = renderHook(() => useFilecoinUpload())
+    await result.current.uploadFile(testFile)
+
+    expect(executeUploadMock).toHaveBeenCalledTimes(2)
+    expect(getOpts()).not.toHaveProperty('dataSetIds')
+    expect(getOpts()).toMatchObject({ contexts: fakeContexts })
+    expect(getStoredDataSetIds('0xabc')).toEqual([])
+    expect(getCachedPieces('0xabc')).toBeNull()
+  })
+
+  it('rethrows resolution-like errors that occur after upload progress started', async () => {
+    addStoredDataSetId('0xabc', 42)
+    useFilecoinPinContextMock.mockReturnValue(baseContext)
+    executeUploadMock.mockImplementationOnce(async (_synapse, _car, _root, opts) => {
+      opts.onProgress?.({ type: 'stored', data: { providerId: 4n, pieceCid: { toString: () => 'bafkpiece' } } })
+      throw new Error('Rail 7 does not exist or is inactive')
+    })
+
+    const { result } = renderHook(() => useFilecoinUpload())
+    await expect(result.current.uploadFile(testFile)).rejects.toThrow('does not exist')
+
+    expect(executeUploadMock).toHaveBeenCalledTimes(1)
+    expect(getStoredDataSetIds('0xabc')).toEqual([42])
+  })
+
+  it('rethrows non-resolution upload errors without retrying', async () => {
+    addStoredDataSetId('0xabc', 42)
+    useFilecoinPinContextMock.mockReturnValue(baseContext)
+    executeUploadMock.mockRejectedValueOnce(new Error('network timeout'))
+
+    const { result } = renderHook(() => useFilecoinUpload())
+    await expect(result.current.uploadFile(testFile)).rejects.toThrow('network timeout')
+
+    expect(executeUploadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('prefers debug providerId over stored dataset ids', async () => {
+    addStoredDataSetId('0xabc', 42)
+    useFilecoinPinContextMock.mockReturnValue({
+      ...baseContext,
+      debugParams: { providerId: 6n, dataSetId: null },
+    })
+
+    const { result } = renderHook(() => useFilecoinUpload())
+    await result.current.uploadFile(testFile)
+
+    expect(getOpts()).toMatchObject({ providerIds: [6n] })
+    expect(getOpts()).not.toHaveProperty('dataSetIds')
   })
 })

--- a/src/hooks/use-filecoin-upload.test.ts
+++ b/src/hooks/use-filecoin-upload.test.ts
@@ -40,6 +40,7 @@ vi.mock('../lib/filecoin-pin/fresh-contexts.ts', () => ({
   createFreshUploadContexts: createFreshUploadContextsMock,
 }))
 
+import { CommitError, StoreError } from '@filoz/synapse-sdk'
 import { addStoredDataSetId, getStoredDataSetIds } from '../lib/local-storage/data-set.ts'
 import { getCachedPieces, setCachedPieces } from '../lib/local-storage/piece-cache.ts'
 import { useFilecoinUpload } from './use-filecoin-upload.ts'
@@ -180,6 +181,48 @@ describe('useFilecoinUpload dataset resume', () => {
     await expect(result.current.uploadFile(testFile)).rejects.toThrow('network timeout')
 
     expect(executeUploadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('recreates data sets when a stored dataset resolves but its provider is offline', async () => {
+    // The dataset resolves (callbacks fire) but the provider is offline, so the
+    // store throws a StoreError before any bytes land. Without recovery every
+    // later upload from this browser re-resolves the same dead provider and
+    // fails.
+    addStoredDataSetId('0xabc', 42)
+    setCachedPieces('0xabc', [{ pieceCid: 'bafkstale' } as never])
+    useFilecoinPinContextMock.mockReturnValue(baseContext)
+    executeUploadMock
+      .mockImplementationOnce(async (_synapse, _car, _root, opts) => {
+        opts.onProgress?.({ type: 'dataSetResolved', data: { dataSetId: 42n, provider: { id: 4n, name: 'p' } } })
+        throw new StoreError('Failed to store on primary provider 4', { providerId: 4n, endpoint: 'https://p' })
+      })
+      .mockResolvedValueOnce({ copies: [], network: 'calibration' })
+
+    const { result } = renderHook(() => useFilecoinUpload())
+    await result.current.uploadFile(testFile)
+
+    expect(executeUploadMock).toHaveBeenCalledTimes(2)
+    expect(getOpts()).toMatchObject({ contexts: fakeContexts })
+    expect(getOpts()).not.toHaveProperty('dataSetIds')
+    expect(getStoredDataSetIds('0xabc')).toEqual([])
+    expect(getCachedPieces('0xabc')).toBeNull()
+  })
+
+  it('rethrows a StoreError that occurs after bytes are stored without recreating data sets', async () => {
+    // After a copy lands (stored event), a later store or commit failure means
+    // the upload progressed past resolution, so it must not recreate datasets.
+    addStoredDataSetId('0xabc', 42)
+    useFilecoinPinContextMock.mockReturnValue(baseContext)
+    executeUploadMock.mockImplementationOnce(async (_synapse, _car, _root, opts) => {
+      opts.onProgress?.({ type: 'stored', data: { providerId: 4n, pieceCid: { toString: () => 'bafkpiece' } } })
+      throw new CommitError('secondary copy commit failed', { providerId: 4n, endpoint: 'https://p' })
+    })
+
+    const { result } = renderHook(() => useFilecoinUpload())
+    await expect(result.current.uploadFile(testFile)).rejects.toThrow('secondary copy commit failed')
+
+    expect(executeUploadMock).toHaveBeenCalledTimes(1)
+    expect(getStoredDataSetIds('0xabc')).toEqual([42])
   })
 
   it('prefers debug providerId over stored dataset ids', async () => {

--- a/src/hooks/use-filecoin-upload.ts
+++ b/src/hooks/use-filecoin-upload.ts
@@ -1,10 +1,18 @@
 import type { PDPProvider } from '@filoz/synapse-sdk'
 import { createCarFromFile } from 'filecoin-pin/core/unixfs'
-import { checkUploadReadiness, executeUpload, type UploadExecutionResult } from 'filecoin-pin/core/upload'
+import {
+  checkUploadReadiness,
+  executeUpload,
+  type UploadExecutionOptions,
+  type UploadExecutionResult,
+} from 'filecoin-pin/core/upload'
 import pino from 'pino'
 import { useCallback, useState } from 'react'
+import { createFreshUploadContexts } from '../lib/filecoin-pin/fresh-contexts.ts'
+import { ensureSessionKeyPermissions } from '../lib/filecoin-pin/synapse.ts'
 import { getOrCreateClientId } from '../lib/local-storage/client-id.ts'
-import { addStoredDataSetId } from '../lib/local-storage/data-set.ts'
+import { addStoredDataSetId, clearStoredDataSetIds, getStoredDataSetIds } from '../lib/local-storage/data-set.ts'
+import { clearCachedPieces } from '../lib/local-storage/piece-cache.ts'
 import type { StepState } from '../types/upload/step.ts'
 import { formatFileSize } from '../utils/format-file-size.ts'
 import { useFilecoinPinContext } from './use-filecoin-pin-context.ts'
@@ -45,6 +53,18 @@ export const INITIAL_STEP_STATES: StepState[] = [
 
 export const INPI_ERROR_MESSAGE =
   "CID not yet indexed by IPNI. It's stored on Filecoin and fetchable now, but may take time to appear on IPFS."
+
+/**
+ * True when executeUpload failed while resolving explicitly-passed dataset ids
+ * (deleted dataset, wrong owner, two datasets on the same provider). Callers
+ * must also confirm no upload progress events fired: dataset resolution
+ * happens before any bytes are uploaded, so message matching alone could
+ * misclassify a later provider or payments error that shares these phrases.
+ */
+const isDataSetResolutionError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error)
+  return /does not exist|not owned by|duplicate providers|not found in registry|resolved to/i.test(message)
+}
 
 /**
  * Handles the end-to-end upload workflow with filecoin-pin:
@@ -113,6 +133,9 @@ export const useFilecoinUpload = () => {
         logger.info('Waiting for synapse to be initialized')
         const synapse = await synapseRef.wait()
         logger.info('Synapse initialized')
+        // Session-key permission checks are deferred from page load to here so
+        // read-only visits make no permission-related RPC calls.
+        await ensureSessionKeyPermissions()
         updateStepState('checking-readiness', { progress: 50 })
 
         logger.info('Checking upload readiness')
@@ -132,20 +155,19 @@ export const useFilecoinUpload = () => {
         logger.info('Upload readiness check completed')
 
         logger.info('Uploading CAR to Synapse')
-        const result = await executeUpload(synapse, carResult.carBytes, carResult.rootCid, {
+        // Distinguishes resolution failures (safe to retry into fresh data
+        // sets) from errors after the upload started.
+        let sawUploadProgress = false
+        const baseOptions: UploadExecutionOptions = {
           logger,
           contextId: `upload-${Date.now()}`,
-          ...(debugParams.providerId != null && { providerIds: [debugParams.providerId] }),
-          // Per-browser metadata so Synapse smart-select gives this browser its
-          // own data set instead of sharing the demo wallet's data sets with
-          // every other visitor (avoids cross-user file visibility + RPC blowup).
-          metadata: { clientId: getOrCreateClientId() },
           pieceMetadata: {
             ...(metadata ?? {}),
             label: file.name,
             fileSize: formatFileSize(file.size),
           },
           onProgress: (event) => {
+            sawUploadProgress = true
             switch (event.type) {
               case 'providerSelected': {
                 const provider = event.data.provider
@@ -264,7 +286,69 @@ export const useFilecoinUpload = () => {
                 break
             }
           },
-        })
+        }
+
+        const walletAddress = wallet?.status === 'ready' ? wallet.data.address : null
+        const storedDataSetIds =
+          debugParams.providerId == null && walletAddress ? getStoredDataSetIds(walletAddress) : []
+
+        // Select providers directly from the registry and create fresh
+        // per-browser datasets during the upload commit, skipping the SDK's
+        // smart-select (which enumerates every dataset on the shared demo
+        // wallet). Falls back to smart-select with per-browser metadata when
+        // no provider is reachable. The created dataset ids are stored on
+        // `piecesConfirmed`, so later uploads take the resume path.
+        const uploadIntoFreshDataSets = async (): Promise<UploadExecutionResult> => {
+          let contexts: Awaited<ReturnType<typeof createFreshUploadContexts>> | null = null
+          try {
+            contexts = await createFreshUploadContexts(synapse, getOrCreateClientId())
+            for (const context of contexts) {
+              const provider = context.provider
+              setUploadState((prev) => ({
+                ...prev,
+                providersById: { ...prev.providersById, [String(provider.id)]: provider },
+              }))
+            }
+          } catch (error) {
+            console.warn('[FilecoinUpload] Fresh context selection failed, falling back to smart-select:', error)
+          }
+          return executeUpload(
+            synapse,
+            carResult.carBytes,
+            carResult.rootCid,
+            contexts == null
+              ? { ...baseOptions, metadata: { clientId: getOrCreateClientId() } }
+              : { ...baseOptions, contexts }
+          )
+        }
+
+        let result: UploadExecutionResult
+        if (debugParams.providerId != null) {
+          result = await executeUpload(synapse, carResult.carBytes, carResult.rootCid, {
+            ...baseOptions,
+            providerIds: [debugParams.providerId],
+            metadata: { clientId: getOrCreateClientId() },
+          })
+        } else if (walletAddress != null && storedDataSetIds.length > 0) {
+          // Resume into this browser's known datasets. Passing explicit ids
+          // skips the SDK's smart-select, which enumerates every dataset on
+          // the shared demo wallet (one eth_call per dataset, unbounded).
+          try {
+            result = await executeUpload(synapse, carResult.carBytes, carResult.rootCid, {
+              ...baseOptions,
+              dataSetIds: storedDataSetIds.map((id) => BigInt(id)),
+            })
+          } catch (error) {
+            if (sawUploadProgress || !isDataSetResolutionError(error)) throw error
+            console.warn('[FilecoinUpload] Stored dataset ids failed to resolve, recreating data sets:', error)
+            clearStoredDataSetIds(walletAddress)
+            clearCachedPieces(walletAddress)
+            result = await uploadIntoFreshDataSets()
+          }
+        } else {
+          // First upload from this browser
+          result = await uploadIntoFreshDataSets()
+        }
         logger.info('Upload completed')
 
         setUploadState((prev) => ({

--- a/src/hooks/use-filecoin-upload.ts
+++ b/src/hooks/use-filecoin-upload.ts
@@ -1,4 +1,4 @@
-import type { PDPProvider } from '@filoz/synapse-sdk'
+import { CommitError, type PDPProvider, StoreError } from '@filoz/synapse-sdk'
 import { createCarFromFile } from 'filecoin-pin/core/unixfs'
 import {
   checkUploadReadiness,
@@ -65,6 +65,15 @@ const isDataSetResolutionError = (error: unknown): boolean => {
   const message = error instanceof Error ? error.message : String(error)
   return /does not exist|not owned by|duplicate providers|not found in registry|resolved to/i.test(message)
 }
+
+/**
+ * True for store and commit failures surfaced by Synapse (`StoreError` /
+ * `CommitError`). On the resume path these indicate the provider behind a
+ * stored dataset id is unreachable. A caller must also confirm no bytes were
+ * stored yet: after a 'stored' event the same error indicates a failure mid-
+ * upload rather than an unreachable resumed provider.
+ */
+const isProviderStoreError = (error: unknown): boolean => StoreError.is(error) || CommitError.is(error)
 
 /**
  * Handles the end-to-end upload workflow with filecoin-pin:
@@ -158,6 +167,10 @@ export const useFilecoinUpload = () => {
         // Distinguishes resolution failures (safe to retry into fresh data
         // sets) from errors after the upload started.
         let sawUploadProgress = false
+        // Set once the primary copy's bytes land on a provider. Past this point
+        // a store or commit failure reflects a problem mid-upload, so the
+        // resume retry below leaves the stored dataset ids in place.
+        let sawBytesStored = false
         const baseOptions: UploadExecutionOptions = {
           logger,
           contextId: `upload-${Date.now()}`,
@@ -188,6 +201,7 @@ export const useFilecoinUpload = () => {
               }
 
               case 'stored':
+                sawBytesStored = true
                 console.debug('[FilecoinUpload] Stored on provider:', String(event.data.providerId))
                 setUploadState((prev) => ({
                   ...prev,
@@ -339,8 +353,19 @@ export const useFilecoinUpload = () => {
               dataSetIds: storedDataSetIds.map((id) => BigInt(id)),
             })
           } catch (error) {
-            if (sawUploadProgress || !isDataSetResolutionError(error)) throw error
-            console.warn('[FilecoinUpload] Stored dataset ids failed to resolve, recreating data sets:', error)
+            // Recoverable failures, both safe to retry into fresh datasets:
+            //   1. Resolution failed: the stored id is gone or owned by another
+            //      wallet. Resolution emits no progress events, so
+            //      sawUploadProgress is still false.
+            //   2. The dataset resolved but its provider is unreachable: a
+            //      StoreError before any bytes landed. Dataset resolution reads
+            //      chain and registry state without contacting the provider, so
+            //      an unreachable provider first surfaces at store time.
+            //      Recreating datasets routes the upload to a reachable provider.
+            const resolutionFailure = !sawUploadProgress && isDataSetResolutionError(error)
+            const deadProviderOnResume = !sawBytesStored && isProviderStoreError(error)
+            if (!resolutionFailure && !deadProviderOnResume) throw error
+            console.warn('[FilecoinUpload] Stored dataset ids unusable, recreating data sets:', error)
             clearStoredDataSetIds(walletAddress)
             clearCachedPieces(walletAddress)
             result = await uploadIntoFreshDataSets()

--- a/src/lib/filecoin-pin/fresh-contexts.ts
+++ b/src/lib/filecoin-pin/fresh-contexts.ts
@@ -1,0 +1,105 @@
+/**
+ * Direct provider selection for a browser's first upload.
+ *
+ * The SDK's smart-select looks for an existing metadata-matching dataset by
+ * enumerating every dataset the wallet owns (one eth_call per dataset). On the
+ * shared demo wallet that is unbounded: the wallet gains one dataset per new
+ * visitor, so the enumeration grows without limit.
+ *
+ * A browser with no stored dataset ids is known to have no matching dataset,
+ * so the search is pointless. This module selects providers straight from the
+ * registry (two RPC calls total) and builds StorageContexts with no dataset
+ * bound; the provider creates the dataset during the upload commit
+ * (CreateDataSetAndAddPieces), exactly as it would after smart-select chose a
+ * provider without a matching dataset.
+ */
+
+import { getEndorsedProviderIds } from '@filoz/synapse-core/endorsements'
+import { ping } from '@filoz/synapse-core/sp'
+import { getApprovedPDPProviders } from '@filoz/synapse-core/sp-registry'
+import { selectProviders } from '@filoz/synapse-core/warm-storage'
+import { METADATA_KEYS } from '@filoz/synapse-sdk'
+import { StorageContext } from '@filoz/synapse-sdk/storage'
+import { WarmStorageService } from '@filoz/synapse-sdk/warm-storage'
+import { filecoinPinConfig } from './config.ts'
+import { APPLICATION_SOURCE, type Synapse } from './synapse.ts'
+
+const DEFAULT_COPIES = 2
+
+const withCDN = ('withCDN' in filecoinPinConfig ? filecoinPinConfig.withCDN : false) ?? false
+
+/**
+ * Select reachable providers (endorsed preferred for the primary copy) and
+ * return upload-ready contexts that create a fresh dataset on commit.
+ *
+ * The dataset metadata matches what the smart-select path would have used, so
+ * datasets created here are interchangeable with SDK-created ones.
+ *
+ * @throws When no reachable provider is available for the primary copy.
+ */
+export async function createFreshUploadContexts(
+  synapse: Synapse,
+  clientId: string,
+  copies = DEFAULT_COPIES
+): Promise<StorageContext[]> {
+  const [providers, endorsedIds] = await Promise.all([
+    getApprovedPDPProviders(synapse.client),
+    getEndorsedProviderIds(synapse.client),
+  ])
+
+  const dataSetMetadata: Record<string, string> = {
+    [METADATA_KEYS.WITH_IPFS_INDEXING]: '',
+    [METADATA_KEYS.SOURCE]: APPLICATION_SOURCE,
+    clientId,
+  }
+
+  const excludeProviderIds: bigint[] = []
+  const selected = []
+  for (let i = 0; i < copies; i++) {
+    // Restrict the primary copy to endorsed providers, mirroring the SDK's
+    // requireEndorsedPrimary behavior; secondaries draw from the full pool.
+    const endorsedSlot = i === 0
+    let found = false
+    while (!found) {
+      const candidates = selectProviders({
+        providers,
+        endorsedIds: endorsedSlot ? endorsedIds : [],
+        clientDataSets: [],
+        count: 1,
+        excludeProviderIds,
+        metadata: dataSetMetadata,
+      })
+      const candidate = candidates[0]
+      if (candidate == null) break
+      excludeProviderIds.push(candidate.provider.id)
+      try {
+        await ping(candidate.provider.pdp.serviceURL)
+        selected.push(candidate.provider)
+        found = true
+      } catch {
+        console.warn('[FreshContexts] Provider unreachable, trying next:', candidate.provider.name)
+      }
+    }
+    if (!found) {
+      if (i === 0) {
+        throw new Error('No reachable storage providers available')
+      }
+      // Fewer providers than requested copies: proceed with reduced redundancy
+      console.warn('[FreshContexts] Only', selected.length, 'reachable provider(s) for', copies, 'copies')
+      break
+    }
+  }
+
+  const warmStorageService = new WarmStorageService({ client: synapse.client })
+  return selected.map(
+    (provider) =>
+      new StorageContext({
+        synapse,
+        warmStorageService,
+        provider,
+        dataSetId: undefined,
+        options: { withCDN },
+        dataSetMetadata,
+      })
+  )
+}

--- a/src/lib/filecoin-pin/fresh-contexts.ts
+++ b/src/lib/filecoin-pin/fresh-contexts.ts
@@ -54,7 +54,7 @@ export async function createFreshUploadContexts(
   }
 
   const excludeProviderIds: bigint[] = []
-  const selected = []
+  const selected: typeof providers = []
   for (let i = 0; i < copies; i++) {
     // Restrict the primary copy to endorsed providers, mirroring the SDK's
     // requireEndorsedPrimary behavior; secondaries draw from the full pool.

--- a/src/lib/filecoin-pin/synapse.ts
+++ b/src/lib/filecoin-pin/synapse.ts
@@ -11,7 +11,7 @@ const logger = pino({
   },
 })
 
-const APPLICATION_SOURCE = 'filecoin-pin'
+export const APPLICATION_SOURCE = 'filecoin-pin'
 const WEBSOCKET_REGEX = /^ws(s)?:\/\//i
 
 function createTransport(rpcUrl: string): HttpTransport | WebSocketTransport {
@@ -33,6 +33,30 @@ function isSessionKeyConfig(
 const REQUIRED_PERMISSIONS = [CreateDataSetPermission, AddPiecesPermission]
 
 /**
+ * Session-key permission check, set during session-key init and run lazily.
+ *
+ * Checking permissions costs RPC calls, so it runs at upload time (the only
+ * point that needs write permissions) rather than on page load. The result is
+ * cached for the session; a failed check is retried on the next call.
+ */
+let validateSessionKey: (() => Promise<void>) | null = null
+let sessionKeyValidation: Promise<void> | null = null
+
+export const ensureSessionKeyPermissions = (): Promise<void> => {
+  if (!validateSessionKey) return Promise.resolve()
+  if (!sessionKeyValidation) {
+    const promise = validateSessionKey()
+    promise.catch(() => {
+      if (sessionKeyValidation === promise) {
+        sessionKeyValidation = null
+      }
+    })
+    sessionKeyValidation = promise
+  }
+  return sessionKeyValidation
+}
+
+/**
  * Inline session-key init that bypasses `Synapse.create`'s permission check.
  *
  * The SDK's `Synapse.create` requires the session key to hold ALL four
@@ -41,9 +65,10 @@ const REQUIRED_PERMISSIONS = [CreateDataSetPermission, AddPiecesPermission]
  * AddPieces on-chain (least privilege), so we go through the public
  * `Synapse` constructor directly.
  *
- * `syncExpirations` is narrowed to the permissions we actually grant; we
- * still validate them ourselves so a misconfigured / expired session key
- * fails fast instead of silently breaking writes later.
+ * `syncExpirations` is narrowed to the permissions we actually grant. The
+ * check is deferred to upload time (see `ensureSessionKeyPermissions`) so a
+ * read-only page visit pays zero RPC calls for it; writes still fail fast
+ * with a clear message when the session key is misconfigured / expired.
  */
 async function initSessionKeySynapse(
   config: Extract<SynapseSetupConfig, { sessionKey: `0x${string}` }>
@@ -61,12 +86,14 @@ async function initSessionKeySynapse(
     transport,
   })
 
-  await sessionKey.syncExpirations(REQUIRED_PERMISSIONS)
-  if (!sessionKey.hasPermissions(REQUIRED_PERMISSIONS)) {
-    throw new Error(
-      'Session key is missing or has expired permissions for CreateDataSet and/or AddPieces. ' +
-        'Re-authorize via scripts/create-session-key.sh and update VITE_SESSION_KEY.'
-    )
+  validateSessionKey = async () => {
+    await sessionKey.syncExpirations(REQUIRED_PERMISSIONS)
+    if (!sessionKey.hasPermissions(REQUIRED_PERMISSIONS)) {
+      throw new Error(
+        'Session key is missing or has expired permissions for CreateDataSet and/or AddPieces. ' +
+          'Re-authorize via scripts/create-session-key.sh and update VITE_SESSION_KEY.'
+      )
+    }
   }
 
   const resolved = transport({ chain, retryCount: 0 })
@@ -76,6 +103,9 @@ async function initSessionKeySynapse(
     account: walletAddress,
     name: 'Synapse Client',
     key: 'synapse-client',
+    // Filecoin calibration produces a block every 30s; poll receipts at 15s
+    // instead of viem's 4s default to cut polling RPC traffic.
+    pollingInterval: 15_000,
   })
 
   logger.info(
@@ -113,4 +143,6 @@ export const getSynapseClient = (config: SynapseSetupConfig) => {
 
 export const resetSynapseClient = () => {
   synapsePromise = null
+  validateSessionKey = null
+  sessionKeyValidation = null
 }

--- a/src/lib/filecoin-pin/wallet.ts
+++ b/src/lib/filecoin-pin/wallet.ts
@@ -1,5 +1,6 @@
 import { getPaymentStatus, type PaymentStatus } from 'filecoin-pin/core/payments'
 import { formatFIL, formatUSDFC } from 'filecoin-pin/core/utils'
+import { filecoinPinConfig } from './config.ts'
 import type { Synapse } from './synapse.ts'
 
 export const shortenAddress = (address: string, visibleChars = 4) => {
@@ -21,11 +22,61 @@ export interface WalletSnapshot {
   raw: PaymentStatus
 }
 
+/**
+ * The payment status query behind the snapshot makes four eth_calls (FIL
+ * balance, USDFC balance, deposited balance, service approval). The snapshot
+ * only drives the header balance display for the shared demo wallet, so it is
+ * fetched once per browser session and reused from sessionStorage on reloads.
+ */
+const SNAPSHOT_CACHE_KEY = 'filecoin-pin-wallet-snapshot-v1'
+
+const BIGINT_TAG = '__bigint__'
+
+const serializeSnapshot = (snapshot: WalletSnapshot): string =>
+  JSON.stringify(snapshot, (_key, value) => (typeof value === 'bigint' ? `${BIGINT_TAG}${value}` : value))
+
+const deserializeSnapshot = (raw: string): WalletSnapshot =>
+  JSON.parse(raw, (_key, value) =>
+    typeof value === 'string' && value.startsWith(BIGINT_TAG) ? BigInt(value.slice(BIGINT_TAG.length)) : value
+  )
+
+const configuredWalletAddress = 'walletAddress' in filecoinPinConfig ? filecoinPinConfig.walletAddress : null
+
+const readCachedSnapshot = (): WalletSnapshot | null => {
+  try {
+    const raw = sessionStorage.getItem(SNAPSHOT_CACHE_KEY)
+    if (!raw) return null
+    const snapshot = deserializeSnapshot(raw)
+    // Ignore a snapshot cached for a different wallet (e.g. config changed
+    // between deploys within the same browser session).
+    if (configuredWalletAddress != null && snapshot.address.toLowerCase() !== configuredWalletAddress.toLowerCase()) {
+      return null
+    }
+    return snapshot
+  } catch {
+    return null
+  }
+}
+
+const writeCachedSnapshot = (snapshot: WalletSnapshot): void => {
+  try {
+    sessionStorage.setItem(SNAPSHOT_CACHE_KEY, serializeSnapshot(snapshot))
+  } catch (error) {
+    console.warn('[Wallet] Failed to cache wallet snapshot:', error)
+  }
+}
+
 export const fetchWalletSnapshot = async (synapse: Synapse): Promise<WalletSnapshot> => {
+  const cached = readCachedSnapshot()
+  if (cached) {
+    console.debug('[Wallet] Using cached wallet snapshot (no RPC)')
+    return cached
+  }
+
   const status = await getPaymentStatus(synapse)
   const isCalibration = status.network === 'calibration'
   const usdfcLabel = isCalibration ? 'tUSDFC' : 'USDFC'
-  return {
+  const snapshot: WalletSnapshot = {
     address: status.address,
     network: status.network,
     filBalance: status.filBalance,
@@ -36,4 +87,6 @@ export const fetchWalletSnapshot = async (synapse: Synapse): Promise<WalletSnaps
     },
     raw: status,
   }
+  writeCachedSnapshot(snapshot)
+  return snapshot
 }

--- a/src/lib/local-storage/data-set.ts
+++ b/src/lib/local-storage/data-set.ts
@@ -112,6 +112,23 @@ export const addStoredDataSetId = (walletAddress: string, dataSetId: number): vo
 }
 
 /**
+ * Remove all stored data set IDs for a wallet (multi-id list and legacy single-id key).
+ *
+ * Used when stored IDs fail to resolve on-chain (e.g. dataset deleted or owned
+ * by a different wallet) so the next upload creates fresh data sets and
+ * re-learns the browser's dataset ids.
+ */
+export const clearStoredDataSetIds = (walletAddress: string): void => {
+  try {
+    localStorage.removeItem(getDataSetIdsKey(walletAddress))
+    localStorage.removeItem(getDataSetStorageKey(walletAddress))
+    console.debug('[DataSetStorage] Cleared stored data set IDs for wallet:', walletAddress)
+  } catch (error) {
+    console.warn('[DataSetStorage] Failed to clear data set IDs from localStorage:', error)
+  }
+}
+
+/**
  * Get the stored data set ID for a specific wallet address and provider ID.
  *
  * This allows testing/debugging with different providers by storing separate

--- a/src/lib/local-storage/piece-cache.ts
+++ b/src/lib/local-storage/piece-cache.ts
@@ -1,0 +1,62 @@
+/**
+ * LocalStorage cache of the upload-history piece list, scoped per wallet.
+ *
+ * Why cache?
+ * ----------
+ * Rebuilding history from chain is expensive: `getDetailedDataSet` costs
+ * several eth_calls per dataset plus one eth_call per piece for metadata
+ * (filename, root CID, tx hash). All of that information is already known
+ * in-browser at upload time, so we persist it here and render history from
+ * cache with zero RPC calls. The chain fetch only runs when there is no cache
+ * (e.g. localStorage was cleared) or when the user explicitly refreshes.
+ */
+
+import type { DatasetPiece } from '../../hooks/use-dataset-pieces.ts'
+
+const PIECE_CACHE_KEY = 'filecoin-pin-piece-cache-v1'
+
+const getPieceCacheKey = (walletAddress: string): string => `${PIECE_CACHE_KEY}-${walletAddress}`
+
+/**
+ * Read the cached piece list for a wallet.
+ *
+ * @returns The cached pieces, or null when no cache exists (never written or
+ * unparseable). An empty array is a valid cache state ("loaded, no uploads").
+ */
+export const getCachedPieces = (walletAddress: string): DatasetPiece[] | null => {
+  try {
+    const raw = localStorage.getItem(getPieceCacheKey(walletAddress))
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return null
+    return parsed as DatasetPiece[]
+  } catch (error) {
+    console.warn('[PieceCache] Failed to read piece cache from localStorage:', error)
+    return null
+  }
+}
+
+/** Replace the cached piece list for a wallet. */
+export const setCachedPieces = (walletAddress: string, pieces: DatasetPiece[]): void => {
+  try {
+    localStorage.setItem(getPieceCacheKey(walletAddress), JSON.stringify(pieces))
+  } catch (error) {
+    console.warn('[PieceCache] Failed to write piece cache to localStorage:', error)
+  }
+}
+
+/** Prepend a piece to the cached list (used after an upload completes). Idempotent by pieceCid. */
+export const addCachedPiece = (walletAddress: string, piece: DatasetPiece): void => {
+  const current = getCachedPieces(walletAddress) ?? []
+  if (current.some((p) => p.pieceCid === piece.pieceCid)) return
+  setCachedPieces(walletAddress, [piece, ...current])
+}
+
+/** Remove the cached piece list. Called alongside clearStoredDataSetIds so cache and ids stay in lockstep. */
+export const clearCachedPieces = (walletAddress: string): void => {
+  try {
+    localStorage.removeItem(getPieceCacheKey(walletAddress))
+  } catch (error) {
+    console.warn('[PieceCache] Failed to clear piece cache from localStorage:', error)
+  }
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,6 +1,40 @@
 import { cleanup } from '@testing-library/react'
 import { afterEach } from 'vitest'
 
+/**
+ * Node 22+ defines an experimental `localStorage` global that is undefined
+ * unless Node is started with `--localstorage-file`, and it shadows jsdom's
+ * implementation. Replace both web storage globals with an in-memory shim so
+ * code under test sees a working Storage API.
+ */
+const createMemoryStorage = (): Storage => {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear: () => {
+      store.clear()
+    },
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+  }
+}
+
+for (const name of ['localStorage', 'sessionStorage'] as const) {
+  Object.defineProperty(globalThis, name, {
+    value: createMemoryStorage(),
+    configurable: true,
+    writable: true,
+  })
+}
+
 // Cleanup after each test
 afterEach(() => {
   cleanup()

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -38,4 +38,6 @@ for (const name of ['localStorage', 'sessionStorage'] as const) {
 // Cleanup after each test
 afterEach(() => {
   cleanup()
+  localStorage.clear()
+  sessionStorage.clear()
 })


### PR DESCRIPTION
### What changed

A visitor session could generate 900–1800+ JSON-RPC calls because two paths scaled with the shared demo wallet's on-chain footprint: every upload ran the SDK's smart-select (one eth_call per dataset the wallet owns — one dataset per visitor browser, growing forever), and history loading fetched piece metadata with one eth_call per piece, re-triggered several times per session.

Uploads now resolve their target without enumeration. Stored dataset ids resume directly via `executeUpload({ dataSetIds })`. A browser with no stored ids selects providers from the registry (two RPC calls) and lets the provider create its datasets during the upload commit (`fresh-contexts.ts`, mirroring the SDK's selection ranking and metadata). History renders from a localStorage piece cache written at upload time; chain enumeration only runs when the cache is missing or on explicit refresh. Smaller wins: wallet snapshot cached per browser session, session-key permission check deferred to upload time, `refreshWallet` deduped, legacy shared-dataset ids purged on mount instead of first upload.

The separate `test:` commit fixes five tests that were already failing on `main` (Node 22+ ships an undefined `localStorage` global that shadows jsdom's).

### How to verify

`npm test` (36 passing). Measured against the live UI with headless Chromium counting JSON-RPC over HTTP and WebSocket frames, with real calibration uploads:

| Scenario | Before | After |
|---|---|---|
| First upload (new browser) | 943 calls / 333s | 18 calls / 78s |
| Repeat upload | 943 every time | 29 |
| Page load | 6–10 | 5 |
| Returning-visitor load | 19+, grows with history | 5, flat |

The repeat upload resumed into the datasets the fresh path created, so direct-created datasets are confirmed resumable, and history rendered both uploads from cache.

### Notes / risks

- History is now cache-first: it can lag on-chain state until an explicit refresh, and a partial refresh failure intentionally skips the cache write rather than persisting an incomplete list.
- If stored dataset ids fail to resolve (deleted/wrong owner), the ids and piece cache are cleared together and the upload retries into fresh datasets — guarded so errors after upload progress never trigger this.
- `fresh-contexts.ts` duplicates the SDK's provider-selection loop; an upstream synapse-sdk option to skip dataset enumeration would let us delete it. Smart-select remains as fallback when no provider is reachable.


closes #166 
hotfix required before we eventually get to #179 , but we should take the learnings from here into whatever we end up implementing for #179 