### PR TITLE
fix: rename upload-action inputs to minRunwayDays/maxBalance

### DIFF
--- a/.github/workflows/filecoin-pin-upload.yml
+++ b/.github/workflows/filecoin-pin-upload.yml
@@ -33,5 +33,5 @@ jobs:
           path: dist  # Path to the downloaded build artifacts
           walletPrivateKey: ${{ secrets.WALLET_PRIVATE_KEY }}
           network: calibration
-          minStorageDays: "30"
-          filecoinPayBalanceLimit: "0.25"
+          minRunwayDays: "30"
+          maxBalance: "0.25"


### PR DESCRIPTION
## What

Rename the two financial inputs passed to the `filecoin-pin/upload-action` in
`.github/workflows/filecoin-pin-upload.yml`:

- `minStorageDays` → `minRunwayDays`
- `filecoinPayBalanceLimit` → `maxBalance`

## Why

The action renamed these inputs in filecoin-project/filecoin-pin#530 and no
longer reads the old names (not even as aliases). Because we pin the action to
`@master`, our workflow silently picked up the breaking change: the old names
were ignored and the runner logged
`Warning: Unexpected input(s) 'minStorageDays', 'filecoinPayBalanceLimit'`.

With the old names dropped, the values never took effect:

- `minRunwayDays` defaulted to `0` → "fund this upload only", no runway pre-funding
- `maxBalance` defaulted to `undefined` → deposits made with **no balance cap**

So our intended budget guardrails (keep 30 days of runway, cap deposits at
0.25) were not being applied. This restores them.

## Notes

- Values unchanged: `30` days / `0.25`.
- The `@master` pin is intentionally left as-is in this PR (out of scope).