### PR TITLE
fix: remove deprecated baseUrl from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
     "customConditions": ["browser"],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@/components/*": ["./src/components/*"],


### PR DESCRIPTION
### What changed

Remove `baseUrl` from `tsconfig.json`. TypeScript 6.0 turns `baseUrl` into an error (`TS5101`), which breaks `tsc` once the `typescript` 6.0 bump in #199 lands. The `paths` aliases (`@/*` → `./src/*`) keep working: with TypeScript 5+, `paths` resolve relative to the tsconfig directory (the repo root), and Vite resolves the same aliases through its own `resolve.alias` config.

### How to verify

- `npm run typecheck` and `npm run build` pass on the current toolchain (TypeScript 5.9).
- Under TypeScript 6.0: `npx -p typescript@~6.0.3 tsc --noEmit` exits 0 with this change, and exits 2 with `TS5101` without it.
- `npm test` passes (44 tests), `@/*` imports still resolve.

### Notes

Independent of #199 and makes the repo build under TypeScript 6.0. After this merges, #199 can rebase, which also lets its `vite build` step run for the first time (it currently fails at `tsc` before reaching the build).
